### PR TITLE
Make startup notification visual-only

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ module.exports = function (app) {
 
     app.setPluginStatus("Started");
 
-    var delta = getAnchorAlarmDelta(app, "normal", "Started")
+    var delta = getAnchorAlarmDelta(app, "normal", "Started", ["visual"])
     app.handleMessage(plugin.id, delta)
     alarm_state = "normal"
 
@@ -762,11 +762,12 @@ function calc_distance(lat1, lon1, lat2, lon2) {
   return d;
 }
 
-function getAnchorAlarmDelta(app, state, msg) {
+function getAnchorAlarmDelta(app, state, msg, method) {
   if (!msg)
     msg = state.charAt(0).toUpperCase() + state.slice(1)
 
-  let method = ["visual", "sound"]
+  if (!method)
+    method = ["visual", "sound"]
 
   var delta = {
     "updates": [


### PR DESCRIPTION
## Summary

Make the plugin startup `Started` notification visual-only.

The existing startup notification uses `getAnchorAlarmDelta(app, "normal", "Started")`,
which currently publishes `method: ["visual", "sound"]`. This PR leaves the
normal alarm/watch notifications unchanged, but passes `["visual"]` for the
startup notification so a non-alarm startup event does not request an audible
notification.

## Context

This addresses the suggestion in #11. On my OpenPlotter setup, the startup
`normal` sound notification combined with OpenPlotter's repeatable normal sound
behavior and resulted in a stale sound loop.

## Testing

- `node --check index.js`
