### PR TITLE
Add configurable default basemap

### DIFF
--- a/src/http-routes.js
+++ b/src/http-routes.js
@@ -72,6 +72,7 @@ function register(app, plugin, router) {
     res.json({
       fleetFilterRadius: config.fleetFilterRadius,
       connectionType: config.connectionType,
+      defaultBasemap: config.defaultBasemap,
     });
   });
 }

--- a/src/schema.js
+++ b/src/schema.js
@@ -125,6 +125,14 @@ function buildSchema(app) {
         default: "WEBSOCKET",
         enum: ["REST_POLLING", "WEBSOCKET"],
       },
+      defaultBasemap: {
+        type: "string",
+        title: "Default Basemap",
+        description:
+          "Which map layer to show on load. Both remain switchable at runtime via the layer control.",
+        default: "Satellite",
+        enum: ["OpenStreetMap", "Satellite"],
+      },
       fleetFilterRadius: {
         type: "integer",
         title: "Fleet Filter Radius (m)",

--- a/ui/js/AnchorAlarm.js
+++ b/ui/js/AnchorAlarm.js
@@ -28,6 +28,7 @@ class AnchorAlarm {
     this.config = {
       connectionType: "WEBSOCKET",
       fleetFilterRadius: 500,
+      defaultBasemap: "Satellite",
     };
 
     this.map = undefined;
@@ -173,6 +174,10 @@ class AnchorAlarm {
         console.error("Failed to load config, using defaults", error);
       })
       .finally(() => {
+        const layer =
+          this.baseMaps[this.config.defaultBasemap] || this.satelliteLayer;
+        layer.addTo(this.map);
+
         if (this.config.connectionType === "WEBSOCKET") {
           console.log("Using Websockets");
           this.setupWebsockets();
@@ -191,8 +196,6 @@ class AnchorAlarm {
   // Splitting it this way lets the status bar exist before any data fetch.
   buildMap() {
     this.map.setView(this.state.getPosition(), 5);
-
-    this.satelliteLayer.addTo(this.map);
 
     L.control.zoom({ position: "topright" }).addTo(this.map);
 


### PR DESCRIPTION
The webapp loads the satellite layer hardcoded in buildMap(). On slow or metered connections OSM is often the better default, but changing it means editing the built client.

Add a `defaultBasemap` plugin option ("OpenStreetMap" or "Satellite", default "Satellite") exposed via /ui-config. The client reads it once after config loads and adds the chosen layer a single time, falling back to satellite for any unset or unrecognized value. Both layers stay switchable at runtime.

Default is unchanged, so existing installs are unaffected.