### PR TITLE
feat: anchorage session log and history-backed tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ I always forget to switch the alarm off before motoring away, so now I don't hav
 
 Historical tracks are color-coded (green for fresh, fading to red as they age) via the [@signalk/tracks-plugin](https://github.com/SignalK/tracks). Other AIS vessels show up too, with their own tracks and accurately-typed icons. Click a vessel for a detailed popup: name, MMSI, length, beam, distance, bearing, SOG, and COG.
 
+### 🕰️ Past anchorages
+
+If your server has a history provider plugin (e.g. [signalk-questdb](https://github.com/dirkwa/signalk-questdb)), the plugin logs every anchoring session (drop and raise times, anchor position, watch zone) and a clock button appears on the map. It opens a list of past anchorages; pick one and its full vessel track is reconstructed from the server's recorded position history and drawn on the map. The same mechanism rehydrates the live scribble track after a server restart mid-anchorage — the in-memory tracks plugin loses it, the history provider doesn't. Without a history provider everything behaves as before.
+
 ### 📊 Heads-up panels
 
 Compact HUD panels for wind (with a wind barb on the map), depth, tide state (plus the next two tides), and anchor status. They show and hide themselves based on what data is actually available, so you're never staring at a panel full of dashes.
@@ -86,6 +90,7 @@ Values are compared case-insensitively; anything other than `true` is treated as
 This app pairs well with some other software:
 
 - **[@signalk/tracks-plugin](https://github.com/SignalK/tracks)**: required for the historical tracks. I recommend a resolution of 1000ms and 86400 points, which gives you high-resolution data for the last 24 hours. If you've got the memory, you might as well use it.
+- **[signalk-questdb](https://github.com/dirkwa/signalk-questdb)** (or any v2 History API provider): enables the past-anchorages browser and makes the live scribble track survive server restarts.
 - **[signalk-tides](https://github.com/bkeepers/signalk-tides)**: feeds the scope calculator and tide panel.
 - **[signalk-autostate](https://github.com/meri-imperiumi/signalk-autostate)**: just by using the anchor app, the plugin can tell the difference between moored and anchored. Great for automating things like an anchor light.
 - **Node-RED + Pushbullet**: for push notifications to your phone. Really great for when you're off the boat, and handy on the boat too.

--- a/src/http-routes.js
+++ b/src/http-routes.js
@@ -195,6 +195,26 @@ export function register(app, plugin, router) {
     }
   });
 
+  // Anchoring session metadata (drop/raise timestamps, anchor position,
+  // zone), newest first. The open session — anchor still down — has no
+  // raisedAt. Tracks are not served here: the UI reconstructs them from the
+  // server's History API using each session's time window.
+  router.get("/sessions", (req, res) => {
+    res.json({ sessions: plugin.sessionLog.all() });
+  });
+
+  router.delete("/sessions/:id", (req, res) => {
+    if (plugin.sessionLog.remove(req.params.id)) {
+      res.json({ statusCode: 200, state: "COMPLETED" });
+    } else {
+      res.status(404).json({
+        statusCode: 404,
+        state: "FAILED",
+        message: "no such session",
+      });
+    }
+  });
+
   router.get("/ui-config", (req, res) => {
     // hasCustomIcon is derived (file existence), not a stored config key, so it
     // rides along on the projection here rather than in schema.js. coerceUiConfig

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import { watchZoneFromConfig } from "../shared/watch-zones/index.js";
 import { Geo } from "../shared/geo.js";
 import { GlitchFilter } from "../shared/glitch-filter.js";
 import { SignalKBus } from "./signalk-bus.js";
+import { SessionLog } from "./session-log.js";
 import { Utils } from "./utils.js";
 import { register as registerHttpRoutes } from "./http-routes.js";
 import { ValidationError, StateError } from "./errors.js";
@@ -55,6 +56,7 @@ export default function (app) {
   plugin.positionGlitched = false;
 
   plugin.bus = new SignalKBus(app, plugin.id);
+  plugin.sessionLog = new SessionLog(app);
 
   // ============================================================
   // PLUGIN LIFECYCLE
@@ -121,6 +123,14 @@ export default function (app) {
 
         plugin.startWatchingPosition();
       }
+
+      // Heal the session log if a restart left it out of sync with the
+      // actual watch state (see SessionLog.reconcile).
+      plugin.sessionLog.reconcile(
+        Boolean(anchorPosition && zone),
+        anchorPosition,
+        zone ? zone.getConfig() : undefined,
+      );
 
       //OLD APIs - only here for backwards compatibility
       if (app.registerActionHandler) {
@@ -596,6 +606,8 @@ export default function (app) {
       position: parsedPosition,
     });
 
+    plugin.sessionLog.start(parsedPosition, resolvedZone.getConfig());
+
     plugin.startWatchingPosition();
     plugin.savePluginOptions();
   };
@@ -641,6 +653,7 @@ export default function (app) {
       ...resolvedZone.getConfig(),
       position: anchorPosition,
     });
+    plugin.sessionLog.updateZone(resolvedZone.getConfig());
     plugin.savePluginOptions();
   };
 
@@ -660,6 +673,8 @@ export default function (app) {
     app.debug("raise anchor");
 
     plugin.updateAnchorState({ isSet: false });
+
+    plugin.sessionLog.end();
 
     delete plugin.configuration.zone;
     plugin.savePluginOptions();

--- a/src/openApi.json
+++ b/src/openApi.json
@@ -26,6 +26,10 @@
     {
       "name": "icon",
       "description": "Custom own-boat icon shown on the map"
+    },
+    {
+      "name": "sessions",
+      "description": "Anchoring session history"
     }
   ],
   "components": {
@@ -124,6 +128,47 @@
           },
           "message": {
             "type": "string"
+          }
+        }
+      },
+      "Session": {
+        "type": "object",
+        "required": ["id", "droppedAt", "position"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "droppedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "raisedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Absent while the anchor is still down."
+          },
+          "droppedAtEstimated": {
+            "type": "boolean",
+            "description": "True when droppedAt was reconstructed at plugin start rather than recorded at the actual drop."
+          },
+          "raisedAtEstimated": {
+            "type": "boolean",
+            "description": "True when raisedAt was reconstructed at plugin start rather than recorded at the actual raise."
+          },
+          "position": {
+            "type": "object",
+            "properties": {
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              }
+            }
+          },
+          "zone": {
+            "type": "object",
+            "description": "Watch zone config snapshot as of the last change during the session."
           }
         }
       }
@@ -419,16 +464,28 @@
             "description": "The custom icon image.",
             "content": {
               "image/png": {
-                "schema": { "type": "string", "format": "binary" }
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               },
               "image/jpeg": {
-                "schema": { "type": "string", "format": "binary" }
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               },
               "image/gif": {
-                "schema": { "type": "string", "format": "binary" }
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               },
               "image/webp": {
-                "schema": { "type": "string", "format": "binary" }
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               }
             }
           },
@@ -436,7 +493,9 @@
             "description": "No custom icon is set.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
                 "example": {
                   "statusCode": 404,
                   "state": "FAILED",
@@ -454,12 +513,30 @@
         "requestBody": {
           "required": true,
           "content": {
-            "image/png": { "schema": { "type": "string", "format": "binary" } },
-            "image/jpeg": {
-              "schema": { "type": "string", "format": "binary" }
+            "image/png": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
             },
-            "image/gif": { "schema": { "type": "string", "format": "binary" } },
-            "image/webp": { "schema": { "type": "string", "format": "binary" } }
+            "image/jpeg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/gif": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/webp": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
           }
         },
         "responses": {
@@ -467,7 +544,9 @@
             "description": "Icon stored successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
               }
             }
           },
@@ -475,7 +554,9 @@
             "description": "Empty upload.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
                 "example": {
                   "statusCode": 400,
                   "state": "FAILED",
@@ -488,7 +569,9 @@
             "description": "Image exceeds the 500 KB size limit.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
                 "example": {
                   "statusCode": 413,
                   "state": "FAILED",
@@ -501,7 +584,9 @@
             "description": "Body is not a recognized jpg/png/gif/webp image.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
                 "example": {
                   "statusCode": 415,
                   "state": "FAILED",
@@ -524,12 +609,79 @@
             "description": "Icon removed (or none was set).",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
               }
             }
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/sessions": {
+      "get": {
+        "tags": ["sessions"],
+        "summary": "List anchoring sessions",
+        "description": "Returns recorded anchoring sessions (one per drop..raise span), newest first. The open session (anchor still down) has no raisedAt. Sessions carry metadata only; the vessel track for a session is reconstructed by querying the server's History API (GET /signalk/v2/api/history/values) for navigation.position over the session's time window.",
+        "responses": {
+          "200": {
+            "description": "Session list returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Session"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{id}": {
+      "delete": {
+        "tags": ["sessions"],
+        "summary": "Delete an anchoring session",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No session with that id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/src/session-log.js
+++ b/src/session-log.js
@@ -1,0 +1,162 @@
+import fs from "fs";
+import path from "path";
+
+// Persistent log of anchoring sessions (one entry per drop..raise span),
+// stored as JSON in the plugin data dir. The sessions carry only metadata —
+// timestamps, anchor position, zone shape. The track itself is not stored
+// here: a history provider (e.g. signalk-questdb) already records
+// navigation.position continuously, so a session's track is reconstructed by
+// querying the History API for the [droppedAt, raisedAt] window.
+//
+// Every public method is a no-throw: anchor alarm operation is safety
+// critical and must never be blocked by a failed bookkeeping write. Errors
+// are reported through app.error and the call becomes a no-op.
+
+const SESSIONS_FILE = "anchor-sessions.json";
+
+// Upper bound on retained sessions; oldest entries fall off. Generous — at a
+// realistic one-drop-per-day this is well over a year of anchorages.
+const MAX_SESSIONS = 500;
+
+export class SessionLog {
+  constructor(app) {
+    this.app = app;
+    this.sessions = null; // lazy-loaded array, oldest first
+  }
+
+  filePath() {
+    return path.join(this.app.getDataDirPath(), SESSIONS_FILE);
+  }
+
+  // Load once, tolerating a missing or corrupt file (fresh install, torn
+  // write) by starting over with an empty log.
+  load() {
+    if (this.sessions)
+      return this.sessions;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath(), "utf8"));
+      this.sessions = Array.isArray(parsed?.sessions) ? parsed.sessions : [];
+    } catch {
+      this.sessions = [];
+    }
+    return this.sessions;
+  }
+
+  // Atomic write (tmp + rename) so a crash mid-write can't tear the log.
+  save() {
+    try {
+      const file = this.filePath();
+      const tmp = `${file}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify({ sessions: this.sessions }, null, 2));
+      fs.renameSync(tmp, file);
+    } catch (err) {
+      this.app.error(`anchor session log write failed: ${err.message}`);
+    }
+  }
+
+  // All sessions, newest first. Returns a deep copy so callers can't mutate
+  // state that a later lifecycle write would then persist.
+  all() {
+    return JSON.parse(JSON.stringify(this.load())).reverse();
+  }
+
+  // The open session (dropped, not yet raised), or null.
+  current() {
+    const sessions = this.load();
+    const last = sessions[sessions.length - 1];
+    return last && !last.raisedAt ? last : null;
+  }
+
+  // Record an anchor drop. An open session at this point means the previous
+  // raise was never recorded (re-drop while watching, or a missed raise) —
+  // close it now so sessions never overlap.
+  start(position, zoneConfig) {
+    try {
+      const sessions = this.load();
+      const now = new Date().toISOString();
+      const open = this.current();
+      if (open)
+        open.raisedAt = now;
+      sessions.push({
+        id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+        droppedAt: now,
+        position: position,
+        zone: zoneConfig,
+      });
+      if (sessions.length > MAX_SESSIONS)
+        sessions.splice(0, sessions.length - MAX_SESSIONS);
+      this.save();
+    } catch (err) {
+      this.app.error(`anchor session log start failed: ${err.message}`);
+    }
+  }
+
+  // Keep the open session's zone in sync when the operator reshapes it.
+  updateZone(zoneConfig) {
+    try {
+      const open = this.current();
+      if (!open)
+        return;
+      open.zone = zoneConfig;
+      this.save();
+    } catch (err) {
+      this.app.error(`anchor session log update failed: ${err.message}`);
+    }
+  }
+
+  // Record the anchor raise. No open session is fine (raise without a
+  // recorded drop, e.g. first run after upgrading to this version).
+  end() {
+    try {
+      const open = this.current();
+      if (!open)
+        return;
+      open.raisedAt = new Date().toISOString();
+      this.save();
+    } catch (err) {
+      this.app.error(`anchor session log end failed: ${err.message}`);
+    }
+  }
+
+  // Reconcile the log with the actual watch state at plugin start, healing
+  // the two ways a restart can leave them out of sync:
+  //  - watching with no open session (log introduced mid-watch, or the drop
+  //    write failed): open one now. droppedAt is the restart time, not the
+  //    true drop — flagged estimated so the UI can say so.
+  //  - not watching but a session is open (crash between raise and the log
+  //    write): close it at restart time, also flagged. The estimate errs
+  //    long — the boat may have sailed after the unrecorded raise — but a
+  //    too-long window only pads the track query, it loses nothing.
+  reconcile(isWatching, position, zoneConfig) {
+    try {
+      const open = this.current();
+      if (isWatching && !open) {
+        this.start(position, zoneConfig);
+        this.current().droppedAtEstimated = true;
+        this.save();
+      } else if (!isWatching && open) {
+        open.raisedAt = new Date().toISOString();
+        open.raisedAtEstimated = true;
+        this.save();
+      }
+    } catch (err) {
+      this.app.error(`anchor session log reconcile failed: ${err.message}`);
+    }
+  }
+
+  // Delete a session by id. Returns true when something was removed.
+  remove(id) {
+    try {
+      const sessions = this.load();
+      const index = sessions.findIndex((s) => s.id === id);
+      if (index === -1)
+        return false;
+      sessions.splice(index, 1);
+      this.save();
+      return true;
+    } catch (err) {
+      this.app.error(`anchor session log remove failed: ${err.message}`);
+      return false;
+    }
+  }
+}

--- a/test/http-routes.test.js
+++ b/test/http-routes.test.js
@@ -179,6 +179,43 @@ describe("http-routes register()", () => {
     });
   });
 
+  describe("sessions routes", () => {
+    test("GET /sessions returns the log newest first", () => {
+      plugin.sessionLog = {
+        all: () => [{ id: "b" }, { id: "a" }],
+      };
+      wire();
+      const res = fakeRes();
+      router.handlers.get["/sessions"]({}, res);
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.body, { sessions: [{ id: "b" }, { id: "a" }] });
+    });
+
+    test("DELETE /sessions/:id returns 200 when removed", () => {
+      let removed;
+      plugin.sessionLog = {
+        remove: (id) => {
+          removed = id;
+          return true;
+        },
+      };
+      wire();
+      const res = fakeRes();
+      router.handlers.delete["/sessions/:id"]({ params: { id: "abc" } }, res);
+      assert.equal(removed, "abc");
+      assert.equal(res.statusCode, 200);
+    });
+
+    test("DELETE /sessions/:id returns 404 for an unknown id", () => {
+      plugin.sessionLog = { remove: () => false };
+      wire();
+      const res = fakeRes();
+      router.handlers.delete["/sessions/:id"]({ params: { id: "nope" } }, res);
+      assert.equal(res.statusCode, 404);
+      assert.equal(res.body.state, "FAILED");
+    });
+  });
+
   describe("GET /ui-config", () => {
     test("returns the whitelisted projection of the config", () => {
       plugin.configuration = {

--- a/test/session-log.test.js
+++ b/test/session-log.test.js
@@ -1,0 +1,140 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { SessionLog } from "../src/session-log.js";
+import { createMockApp } from "./mockApp.js";
+
+const POSITION = { latitude: 12.5, longitude: -61.4 };
+const ZONE = { type: "circle", radius: 50 };
+
+describe("SessionLog", () => {
+  let mock;
+  let log;
+
+  beforeEach(() => {
+    mock = createMockApp();
+    log = new SessionLog(mock.app);
+  });
+
+  afterEach(() => {
+    mock.cleanupDataDir();
+  });
+
+  test("starts empty on a fresh data dir", () => {
+    assert.deepEqual(log.all(), []);
+    assert.equal(log.current(), null);
+  });
+
+  test("start records a session with droppedAt and no raisedAt", () => {
+    log.start(POSITION, ZONE);
+    const open = log.current();
+    assert.ok(open);
+    assert.ok(open.id);
+    assert.ok(Date.parse(open.droppedAt));
+    assert.equal(open.raisedAt, undefined);
+    assert.deepEqual(open.position, POSITION);
+    assert.deepEqual(open.zone, ZONE);
+  });
+
+  test("end stamps raisedAt and closes the session", () => {
+    log.start(POSITION, ZONE);
+    log.end();
+    assert.equal(log.current(), null);
+    const [session] = log.all();
+    assert.ok(Date.parse(session.raisedAt));
+  });
+
+  test("end without an open session is a no-op", () => {
+    log.end();
+    assert.deepEqual(log.all(), []);
+  });
+
+  test("re-drop closes the previous open session so sessions never overlap", () => {
+    log.start(POSITION, ZONE);
+    log.start({ latitude: 13, longitude: -61 }, ZONE);
+    const sessions = log.all(); // newest first
+    assert.equal(sessions.length, 2);
+    assert.equal(sessions[0].raisedAt, undefined);
+    assert.ok(Date.parse(sessions[1].raisedAt));
+  });
+
+  test("updateZone rewrites the open session's zone only", () => {
+    log.start(POSITION, ZONE);
+    log.updateZone({ type: "circle", radius: 80 });
+    assert.equal(log.current().zone.radius, 80);
+    log.end();
+    log.updateZone({ type: "circle", radius: 99 });
+    assert.equal(log.all()[0].zone.radius, 80);
+  });
+
+  test("persists across instances (survives a plugin restart)", () => {
+    log.start(POSITION, ZONE);
+    const reloaded = new SessionLog(mock.app);
+    const open = reloaded.current();
+    assert.ok(open);
+    assert.deepEqual(open.position, POSITION);
+  });
+
+  test("tolerates a corrupt sessions file by starting over", () => {
+    fs.writeFileSync(log.filePath(), "{not json");
+    assert.deepEqual(log.all(), []);
+    log.start(POSITION, ZONE);
+    assert.ok(log.current());
+  });
+
+  test("all() returns newest first", () => {
+    log.start(POSITION, ZONE);
+    log.end();
+    log.start({ latitude: 14, longitude: -60 }, ZONE);
+    const sessions = log.all();
+    assert.equal(sessions[0].position.latitude, 14);
+    assert.equal(sessions[1].position.latitude, 12.5);
+  });
+
+  describe("reconcile", () => {
+    test("watching with no open session opens an estimated one", () => {
+      log.reconcile(true, POSITION, ZONE);
+      const open = log.current();
+      assert.ok(open);
+      assert.equal(open.droppedAtEstimated, true);
+      assert.deepEqual(open.position, POSITION);
+    });
+
+    test("not watching with an open session closes it as estimated", () => {
+      log.start(POSITION, ZONE);
+      log.reconcile(false);
+      assert.equal(log.current(), null);
+      const [session] = log.all();
+      assert.ok(Date.parse(session.raisedAt));
+      assert.equal(session.raisedAtEstimated, true);
+    });
+
+    test("in-sync states are left untouched", () => {
+      log.start(POSITION, ZONE);
+      log.reconcile(true, POSITION, ZONE);
+      assert.equal(log.all().length, 1);
+      assert.equal(log.current().droppedAtEstimated, undefined);
+
+      log.end();
+      log.reconcile(false);
+      assert.equal(log.all().length, 1);
+      assert.equal(log.all()[0].raisedAtEstimated, undefined);
+    });
+  });
+
+  test("remove deletes by id and reports unknown ids", () => {
+    log.start(POSITION, ZONE);
+    const { id } = log.current();
+    assert.equal(log.remove("nope"), false);
+    assert.equal(log.remove(id), true);
+    assert.deepEqual(log.all(), []);
+  });
+
+  test("a failed write reports through app.error instead of throwing", () => {
+    log.start(POSITION, ZONE);
+    // Make the data dir unwritable by replacing it with a file path target.
+    log.filePath = () => "/nonexistent-dir/anchor-sessions.json";
+    log.end();
+    assert.ok(mock.calls.errors.length > 0);
+  });
+});

--- a/ui/js/AnchorAlarm.js
+++ b/ui/js/AnchorAlarm.js
@@ -19,6 +19,7 @@ import { loadChartLayers, CHART_PANE, CHART_PANE_Z_INDEX } from "./ChartLayers.j
 import { AnchorOverlay } from "./hud/AnchorOverlay.js";
 import { AnchorController } from "./AnchorController.js";
 import { ControlToolbar } from "./hud/ControlToolbar.js";
+import { AnchorageHistoryControl } from "./hud/AnchorageHistoryControl.js";
 import { ConfigPanel } from "./hud/ConfigPanel.js";
 import { ThemeControl } from "./hud/ThemeControl.js";
 import { Modal } from "./hud/Modal.js";
@@ -322,6 +323,8 @@ class AnchorAlarm {
         this.anchorController.estimateAnchorPosition();
         this.updateMap();
         this.map.fitBounds(this.anchorOverlay.getBounds());
+
+        this.initAnchorageHistory();
       })
       .catch((error) => {
         const detail = error.statusText || error.message || "unknown error";
@@ -487,6 +490,59 @@ class AnchorAlarm {
       this.fleetLayer?.setOwnBoatIcon(null);
       return result;
     });
+  }
+
+  // Anchorage history rides on the server's v2 History API, which only
+  // exists when a history provider plugin (e.g. signalk-questdb) is
+  // installed. Probe once at startup: when available, add the past-anchorages
+  // control and — if we started mid-session, e.g. after a server restart —
+  // rehydrate the live scribble track from recorded history, which the
+  // in-memory tracks plugin has lost. Without a provider this is a silent
+  // no-op and the app behaves exactly as before.
+  initAnchorageHistory() {
+    this.signalK.probeHistory().then((available) => {
+      if (!available || !this.map)
+        return;
+
+      this.historyControl = new AnchorageHistoryControl({
+        signalK: this.signalK,
+        statusBar: this.statusBar,
+        getLoggedIn: () => this.state.loggedIn,
+      });
+      this.map.addControl(this.historyControl);
+
+      if (this.state.isAnchored())
+        this.rehydrateOwnTrack();
+    });
+  }
+
+  // Replace the own-boat scribble track with the full current-session track
+  // from the History API (droppedAt → now). Failures are non-fatal: the
+  // tracks-plugin buffer (however much survived) keeps being used.
+  rehydrateOwnTrack() {
+    this.signalK
+      .fetchSessions()
+      .then(({ sessions }) => {
+        const open = sessions && sessions.find((s) => !s.raisedAt);
+        if (!open)
+          return;
+        const from = open.droppedAt;
+        const to = new Date().toISOString();
+        const durationSec = Math.max(1, (Date.parse(to) - Date.parse(from)) / 1000);
+        // Same point budget as the anchorage-history display: cap what a
+        // days-long session sends over and hands to the hotline.
+        const resolution = Math.max(1, Math.ceil(durationSec / 2000));
+        return this.signalK
+          .fetchPositionHistory(from, to, resolution)
+          .then((response) => {
+            const positions = SignalKHelper.positionsFromHistory(response);
+            if (positions.length)
+              this.fleetLayer?.seedOwnTrack(positions, resolution * 1000);
+          });
+      })
+      .catch((error) => {
+        console.warn("Own-track rehydration from history failed", error);
+      });
   }
 
   setupConnection() {

--- a/ui/js/SignalKHelper.js
+++ b/ui/js/SignalKHelper.js
@@ -160,6 +160,83 @@ export class SignalKHelper {
   fetchTracks(radius) {
     return this.request(`tracks?radius=${radius}`);
   }
+  // Recorded anchoring sessions (drop/raise spans) from the plugin's session
+  // log, newest first. Plain fetch rather than pluginFetch on purpose: this is
+  // called silently at startup (track rehydration), and a 401 there must
+  // reject quietly instead of popping the login modal uninvited.
+  fetchSessions() {
+    return fetch(`${this.baseUrl}/plugins/${this.pluginName}/sessions`)
+      .then(SignalKHelper._toJsonOrReject);
+  }
+  deleteSession(id) {
+    return this.pluginFetch(`sessions/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+  }
+  // Fetch own-vessel position history from the server's v2 History API,
+  // served by a history provider plugin (e.g. signalk-questdb). `from`/`to`
+  // are ISO timestamps; `resolution` (seconds) downsamples server-side so a
+  // multi-day anchorage doesn't return every raw fix. Rejects on HTTP error —
+  // including the 404/501 when no history provider is installed, which
+  // callers treat as "history unavailable".
+  // Timeout mirrors request() so a provider that accepts the connection but
+  // never answers (flaky boat network) can't hang callers — the startup
+  // probe in particular must always settle. History queries scan a database,
+  // so the deadline is more generous than request()'s 5s.
+  fetchPositionHistory(from, to, resolution) {
+    const params = new URLSearchParams({
+      from,
+      to,
+      paths: "navigation.position",
+    });
+    if (resolution)
+      params.set("resolution", String(resolution));
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort("Request timed out"), 15000);
+    return fetch(
+      `${this.baseUrl}/signalk/v2/api/history/values?${params.toString()}`,
+      { signal: controller.signal },
+    )
+      .finally(() => clearTimeout(timer))
+      .then(SignalKHelper._toJsonOrReject);
+  }
+  // Whether a history provider is available: a minimal one-minute values
+  // query that any provider satisfies cheaply. Resolves a boolean, never
+  // rejects, so startup can branch without try/catch.
+  probeHistory() {
+    const to = new Date();
+    const from = new Date(to.getTime() - 60 * 1000);
+    return this.fetchPositionHistory(from.toISOString(), to.toISOString(), 60)
+      .then(() => true)
+      .catch(() => false);
+  }
+  // Flatten a v2 History API values response (columns per requested path)
+  // into [{time, latitude, longitude}] for the navigation.position column,
+  // skipping the null rows a SAMPLE BY fill produces for empty buckets.
+  static positionsFromHistory(response) {
+    if (!response || !Array.isArray(response.data))
+      return [];
+    const index = (response.values || []).findIndex(
+      (v) => v.path === "navigation.position",
+    );
+    if (index === -1)
+      return [];
+    const positions = [];
+    for (const row of response.data) {
+      const value = row[index + 1]; // row[0] is the timestamp
+      if (
+        value &&
+        typeof value.latitude === "number" &&
+        typeof value.longitude === "number"
+      )
+        positions.push({
+          time: row[0],
+          latitude: value.latitude,
+          longitude: value.longitude,
+        });
+    }
+    return positions;
+  }
   // Fetch the local chart catalog from the v2 resources API (populated by a
   // charts provider plugin such as @signalk/charts-plugin). Hits the v2 path
   // directly since request() is hardwired to /signalk/v1/api/. Rejects like the

--- a/ui/js/hud/AnchorageHistoryControl.js
+++ b/ui/js/hud/AnchorageHistoryControl.js
@@ -1,0 +1,341 @@
+// Leaflet map overlay control: a button that opens the "Past Anchorages"
+// dialog. Sessions come from the plugin's session log (drop/raise metadata
+// only); selecting one reconstructs its vessel track by querying the server's
+// v2 History API for navigation.position over the session's time window and
+// draws it as a dedicated layer (polyline + anchor point), separate from the
+// live FleetLayer tracks. Only added to the map when a history provider is
+// available (see AnchorAlarm.initAnchorageHistory).
+//
+// Element classes are CSS hooks in style.css; do not rename without updating it.
+
+import { Modal } from "./Modal.js";
+import { setTitle } from "../BrowserSupport.js";
+import { SignalKHelper } from "../SignalKHelper.js";
+
+// bootstrap-icons: bi-clock-history.
+const HISTORY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-clock-history" viewBox="0 0 16 16">
+  <path d="M8.515 1.019A7 7 0 0 0 8 1V0a8 8 0 0 1 .589.022zm2.004.45a7 7 0 0 0-.985-.299l.219-.976q.576.129 1.126.342zm1.37.71a7 7 0 0 0-.439-.27l.493-.87a8 8 0 0 1 .979.654l-.615.789a7 7 0 0 0-.418-.302zm1.834 1.79a7 7 0 0 0-.653-.796l.724-.69q.406.429.747.91zm.744 1.352a7 7 0 0 0-.214-.468l.893-.45a8 8 0 0 1 .45 1.088l-.95.313a7 7 0 0 0-.179-.483m.53 2.507a7 7 0 0 0-.1-1.025l.985-.17q.1.58.116 1.17zm-.131 1.538q.05-.254.081-.51l.993.123a8 8 0 0 1-.23 1.155l-.964-.267q.069-.247.12-.501m-.952 2.379q.276-.436.486-.908l.914.405q-.24.54-.555 1.038zm-.964 1.205q.183-.183.35-.378l.758.653a8 8 0 0 1-.401.432z"/>
+  <path d="M8 1a7 7 0 1 0 4.95 11.95l.707.707A8.001 8.001 0 1 1 8 0z"/>
+  <path d="M7.5 3a.5.5 0 0 1 .5.5v5.21l3.248 1.856a.5.5 0 0 1-.496.868l-3.5-2A.5.5 0 0 1 7 9V3.5a.5.5 0 0 1 .5-.5"/>
+</svg>`;
+
+// bootstrap-icons: bi-trash3 (per-row delete).
+const TRASH_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-trash3" viewBox="0 0 16 16">
+  <path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5M11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1zm1.958 1-.846 10.58a1 1 0 0 1-.997.92h-6.23a1 1 0 0 1-.997-.92L3.042 3.5zm-7.487 1a.5.5 0 0 1 .528.47l.5 8.5a.5.5 0 0 1-.998.06L5 5.03a.5.5 0 0 1 .47-.53Zm5.058 0a.5.5 0 0 1 .47.53l-.5 8.5a.5.5 0 1 1-.998-.06l.5-8.5a.5.5 0 0 1 .528-.47M8 4.5a.5.5 0 0 1 .5.5v8.5a.5.5 0 0 1-1 0V5a.5.5 0 0 1 .5-.5"/>
+</svg>`;
+
+// Track styling for a displayed historical session. Distinct from the live
+// hotline tracks (red→green gradient) so the two never read as the same thing.
+const HISTORY_TRACK_STYLE = {
+  color: "#b45bff",
+  weight: 2,
+  opacity: 0.9,
+};
+const HISTORY_ANCHOR_STYLE = {
+  radius: 6,
+  color: "#b45bff",
+  fillColor: "#b45bff",
+  fillOpacity: 0.6,
+  weight: 2,
+};
+
+// Target point budget for a fetched track: pick the History API resolution so
+// even a weeks-long anchorage comes back as roughly this many samples.
+const TRACK_POINT_BUDGET = 2000;
+
+// Format an ISO timestamp for the session list; falls back to the raw string
+// if it doesn't parse.
+function formatWhen(iso) {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms))
+    return String(iso);
+  return new Date(ms).toLocaleString([], {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// Human duration of a session ("3h 20m", "2d 5h"). An open session runs to now.
+function formatDuration(droppedAt, raisedAt) {
+  const start = Date.parse(droppedAt);
+  const end = raisedAt ? Date.parse(raisedAt) : Date.now();
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start)
+    return "";
+  const minutes = Math.round((end - start) / 60000);
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  const mins = minutes % 60;
+  if (days)
+    return `${days}d ${hours}h`;
+  if (hours)
+    return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+export const AnchorageHistoryControl = L.Control.extend({
+  options: {
+    position: "topleft",
+  },
+
+  // opts: { signalK, statusBar, getLoggedIn }
+  initialize: function (opts) {
+    L.Control.prototype.initialize.call(this);
+    this._signalK = opts.signalK;
+    this._statusBar = opts.statusBar;
+    this._getLoggedIn = opts.getLoggedIn || (() => false);
+    this._layer = null; // layer group of the currently displayed track
+    this._shownSessionId = null;
+    this._modal = null;
+  },
+
+  onAdd: function (map) {
+    this._map = map;
+    const container = L.DomUtil.create("div", "leaflet-bar leaflet-control");
+    const button = L.DomUtil.create("a", "leaflet-control-history", container);
+    button.href = "#";
+    button.setAttribute("role", "button");
+    button.innerHTML = HISTORY_ICON;
+    setTitle(button, "Past anchorages");
+
+    L.DomEvent.disableClickPropagation(container);
+    L.DomEvent.on(button, "click", (e) => {
+      L.DomEvent.stop(e);
+      this.openDialog();
+    });
+
+    return container;
+  },
+
+  onRemove: function () {
+    this.clearTrack();
+  },
+
+  // === Dialog =====================================================================
+
+  openDialog: function () {
+    if (this._modal && this._modal.isOpen())
+      return;
+
+    const modal = new Modal({ title: "Past Anchorages" });
+    this._modal = modal;
+
+    const body = document.createElement("div");
+    body.className = "sessionList";
+    body.textContent = "Loading…";
+    modal.setContent(body);
+
+    const buttons = [{ label: "Close", variant: "secondary", value: null }];
+    if (this._shownSessionId) {
+      buttons.unshift({
+        label: "Hide track",
+        variant: "secondary",
+        onClick: (m) => {
+          this.clearTrack();
+          m.close();
+        },
+      });
+    }
+    modal.setButtons(buttons);
+    modal.open();
+
+    this._signalK
+      .fetchSessions()
+      .then(({ sessions }) => {
+        if (!modal.isOpen())
+          return;
+        this.renderSessions(body, sessions, modal);
+      })
+      .catch((error) => {
+        if (!modal.isOpen())
+          return;
+        body.textContent = "";
+        modal.setError(
+          `Failed to load sessions: ${error.message || error.statusText || "unknown error"}`,
+        );
+      });
+  },
+
+  renderSessions: function (body, sessions, modal) {
+    body.innerHTML = "";
+    if (!sessions || !sessions.length) {
+      const empty = document.createElement("p");
+      empty.className = "modalMessage";
+      empty.textContent =
+        "No anchoring sessions recorded yet. Sessions are logged each time the anchor is dropped.";
+      body.appendChild(empty);
+      return;
+    }
+
+    for (const session of sessions) {
+      const row = document.createElement("div");
+      row.className = "sessionRow";
+      // Selecting a session is the dialog's primary action — make each row a
+      // real button for keyboard and screen-reader users.
+      row.setAttribute("role", "button");
+      row.tabIndex = 0;
+      row.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          row.click();
+        }
+      });
+      if (session.id === this._shownSessionId)
+        row.classList.add("shown");
+
+      const info = document.createElement("div");
+      info.className = "sessionInfo";
+      const when = document.createElement("div");
+      when.className = "sessionWhen";
+      when.textContent = formatWhen(session.droppedAt);
+      const detail = document.createElement("div");
+      detail.className = "sessionDetail";
+      const duration = formatDuration(session.droppedAt, session.raisedAt);
+      const state = session.raisedAt ? duration : `${duration} — still anchored`;
+      const estimated =
+        session.droppedAtEstimated || session.raisedAtEstimated
+          ? " (approx.)"
+          : "";
+      detail.textContent = `${state}${estimated}`;
+      info.appendChild(when);
+      info.appendChild(detail);
+      row.appendChild(info);
+
+      // Delete is destructive and auth-gated server-side; only offer it to
+      // logged-in users so anonymous taps don't dead-end in the login modal.
+      if (this._getLoggedIn()) {
+        const del = document.createElement("button");
+        del.type = "button";
+        del.className = "sessionDelete";
+        del.innerHTML = TRASH_ICON;
+        setTitle(del, "Delete this session");
+        del.addEventListener("click", async (e) => {
+          e.stopPropagation();
+          modal.close();
+          const ok = await Modal.confirm({
+            title: "Delete session?",
+            message: `Delete the anchorage from ${formatWhen(session.droppedAt)}? The recorded position history is not affected.`,
+            okLabel: "Delete",
+          });
+          if (ok) {
+            try {
+              await this._signalK.deleteSession(session.id);
+              if (session.id === this._shownSessionId)
+                this.clearTrack();
+            } catch (error) {
+              this._statusBar.set(
+                "anchorage-history",
+                `Failed to delete session: ${error.message || error.statusText || "unknown error"}`,
+                "warning",
+              );
+            }
+          }
+          this.openDialog();
+        });
+        row.appendChild(del);
+      }
+
+      row.addEventListener("click", () => {
+        modal.close();
+        this.showSession(session);
+      });
+      body.appendChild(row);
+    }
+  },
+
+  // === Track display ==============================================================
+
+  showSession: function (session) {
+    const from = session.droppedAt;
+    const to = session.raisedAt || new Date().toISOString();
+    const durationSec = Math.max(
+      1,
+      (Date.parse(to) - Date.parse(from)) / 1000,
+    );
+    const resolution = Math.max(1, Math.ceil(durationSec / TRACK_POINT_BUDGET));
+
+    this._statusBar.clear("anchorage-history");
+    // Guard against out-of-order responses: if another session is picked
+    // while this fetch is in flight, whichever response lands last must not
+    // overwrite the newer selection. Only the latest request may draw.
+    this._pendingSessionId = session.id;
+    this._signalK
+      .fetchPositionHistory(from, to, resolution)
+      .then((response) => {
+        if (this._pendingSessionId !== session.id)
+          return;
+        const positions = SignalKHelper.positionsFromHistory(response);
+        this.drawTrack(session, positions);
+      })
+      .catch((error) => {
+        if (this._pendingSessionId !== session.id)
+          return;
+        this._statusBar.set(
+          "anchorage-history",
+          `Failed to load track: ${error.message || error.statusText || "unknown error"}`,
+          "warning",
+        );
+      });
+  },
+
+  drawTrack: function (session, positions) {
+    this.clearTrack();
+
+    const layers = [];
+    if (positions.length >= 2) {
+      layers.push(
+        L.polyline(
+          positions.map((p) => [p.latitude, p.longitude]),
+          HISTORY_TRACK_STYLE,
+        ),
+      );
+    }
+
+    // The anchor point itself, with the session summary as its popup.
+    if (session.position) {
+      const marker = L.circleMarker(
+        [session.position.latitude, session.position.longitude],
+        HISTORY_ANCHOR_STYLE,
+      );
+      const duration = formatDuration(session.droppedAt, session.raisedAt);
+      const until = session.raisedAt ? formatWhen(session.raisedAt) : "now";
+      marker.bindPopup(
+        `<b>Anchorage</b><br>${formatWhen(session.droppedAt)} → ${until}<br>${duration}, ${positions.length} track points`,
+      );
+      layers.push(marker);
+    }
+
+    if (!layers.length) {
+      this._statusBar.set(
+        "anchorage-history",
+        "No position history recorded for that session.",
+        "warning",
+      );
+      return;
+    }
+
+    this._layer = L.layerGroup(layers).addTo(this._map);
+    this._shownSessionId = session.id;
+
+    const bounds = positions.length
+      ? L.latLngBounds(positions.map((p) => [p.latitude, p.longitude]))
+      : L.latLngBounds([
+        [session.position.latitude, session.position.longitude],
+      ]);
+    this._map.fitBounds(bounds.pad(0.3));
+  },
+
+  clearTrack: function () {
+    if (this._layer) {
+      this._map.removeLayer(this._layer);
+      this._layer = null;
+    }
+    this._shownSessionId = null;
+    // Also void any in-flight track fetch so "Hide track" can't be undone by
+    // a late response. drawTrack is unaffected: its caller's guard runs
+    // before it calls in here.
+    this._pendingSessionId = null;
+  },
+});

--- a/ui/js/hud/FleetLayer.js
+++ b/ui/js/hud/FleetLayer.js
@@ -592,6 +592,12 @@ export class FleetLayer {
       const mmsi = match[1];
       const data = tracks[uri];
 
+      // A history-seeded own track (see seedOwnTrack) is a superset of the
+      // tracks plugin's in-memory buffer — don't let the shorter one clobber
+      // it. Live appends extend the seeded track either way.
+      if (this.isOwnTrack(mmsi) && this.ownTrackSeeded)
+        continue;
+
       const history = data.coordinates?.[0];
       if (!history || !history.length)
         continue;
@@ -645,6 +651,38 @@ export class FleetLayer {
       this.vesselTracks[mmsi] = this.createTrack(points, points.length, mmsi);
       this.trackPointCounts[mmsi] = this.vesselTracks[mmsi].getLatLngs().length;
     }
+  }
+
+  // Replace (or create) the own-boat scribble track from positions fetched
+  // off the server's History API — used at startup to rehydrate the current
+  // anchoring session's track, which the tracks plugin loses on a server
+  // restart. Positions are [{latitude, longitude}] oldest first. Applies the
+  // same synthetic-clock glitch filtering as the bulk /tracks load — but the
+  // clock must advance by the History API sampling interval the caller
+  // actually requested, or coarse samples from a long session would be
+  // judged at an artificially inflated speed and discarded. No radius
+  // filter: an anchor session's track is inherently local. Live deltas keep
+  // extending the seeded track through addPointToTrack.
+  seedOwnTrack(positions, sampleIntervalMs = TRACK_POINT_INTERVAL_MS) {
+    const glitchFilter = new GlitchFilter(this.glitchFilterSpeed);
+    const points = [];
+    let syntheticTime = 0;
+    for (const position of positions) {
+      syntheticTime += sampleIntervalMs;
+      if (!glitchFilter.check(position, syntheticTime).accepted)
+        continue;
+      points.push([position.latitude, position.longitude, points.length]);
+    }
+    if (!points.length)
+      return;
+
+    const mmsi = String(this.ownMmsi);
+    if (this.vesselTracks[mmsi])
+      this.map.removeLayer(this.vesselTracks[mmsi]);
+    this.vesselTracks[mmsi] = this.createTrack(points, points.length, mmsi);
+    this.trackPointCounts[mmsi] = this.vesselTracks[mmsi].getLatLngs().length;
+    this.ownTrackSeeded = true;
+    console.log(`Own track rehydrated from history: ${points.length} points`);
   }
 
   // Single entry point for extending any vessel track. Handles dedupe,

--- a/ui/style.css
+++ b/ui/style.css
@@ -625,7 +625,8 @@ html.dark #polygonControl select {
 
 .leaflet-control-home,
 .leaflet-control-config,
-.leaflet-control-theme {
+.leaflet-control-theme,
+.leaflet-control-history {
   display: flex !important;
   align-items: center;
   justify-content: center;
@@ -789,6 +790,58 @@ html.dark #polygonControl select {
 .modalButton:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+/* Past Anchorages dialog (see ui/js/hud/AnchorageHistoryControl.js): a
+   scrollable list of recorded sessions, one clickable row each. */
+.sessionList {
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.sessionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sessionRow:hover,
+.sessionRow:focus-visible {
+  background-color: var(--surface-hover);
+}
+
+.sessionRow + .sessionRow {
+  border-top: 1px solid var(--divider);
+}
+
+.sessionRow.shown {
+  background-color: var(--surface-faint);
+}
+
+.sessionWhen {
+  font-weight: bold;
+}
+
+.sessionDetail {
+  font-size: 13px;
+  color: var(--surface-muted);
+}
+
+.sessionDelete {
+  -webkit-appearance: none;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--surface-muted);
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.sessionDelete:hover {
+  color: var(--danger);
 }
 
 #configForm {


### PR DESCRIPTION
This adds a persistent log of anchoring sessions and, when the server has a v2 History API provider (e.g. signalk-questdb), a way to browse past anchorages and see their tracks.

## What it does

- Every drop→raise span is recorded to `anchor-sessions.json` in the plugin data dir: drop/raise timestamps, anchor position, watch zone snapshot. Exposed via `GET /sessions` and `DELETE /sessions/:id` (OpenAPI included). Only metadata is stored — the track itself is reconstructed on demand from the server's recorded `navigation.position` history, so there's no second copy of the data.
- The web UI probes the History API once at startup. When available, a clock button opens a **Past Anchorages** dialog listing the sessions; picking one fetches its position history (server-side downsampled to ~2000 points) and draws the track plus the anchor point on the map.
- The same mechanism rehydrates the live scribble track when the app loads mid-anchorage after a server restart — the in-memory tracks-plugin buffer doesn't survive one, recorded history does. It also gives you an own-boat track when tracks-plugin isn't installed at all.
- Without a history provider the probe fails quietly and everything behaves exactly as before.

## Design notes

- Session logging never throws and writes atomically (tmp + rename): bookkeeping must not be able to block a drop or raise. A reconcile step at plugin start heals drop/raise events lost to a crash, flagging reconstructed timestamps as `*Estimated` (shown as "approx." in the dialog).
- A re-drop while watching closes the previous session first, so sessions never overlap. The log is capped at 500 entries.
- `fetchSessions` deliberately bypasses the 401-handling plugin fetch so the silent startup rehydration can't pop the login modal.
- History fetches carry a 15s abort timeout so a hung provider can't stall startup.

Note: for this to work well with signalk-questdb, dirkwa/signalk-questdb#70 is needed — without it `navigation.anchor.position` (re-emitted every fix while watching) pollutes its position table and reconstructed tracks zig-zag between boat and anchor.

## Tested

- `npm test` — 257 tests pass (17 new: SessionLog unit tests + sessions route tests).
- `npm run format:check` and `npm run build:ui` clean.
- Live e2e against signalk-server + QuestDB with a simulated boat swinging at anchor, driven headless in Chromium: history button appears only when a provider responds, session list renders (open session shown as "still anchored"), selecting a session draws the track, and after a hard server restart mid-anchorage the scribble track rehydrates from history (tracks-plugin not installed in the harness). Raise closes the session with a real `raisedAt`.