### PR TITLE
feat: sync anchor watch with TimeZero over LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Compact HUD panels for wind (with a wind barb on the map), depth, tide state (pl
 
 Logged-in users can tweak the UI without leaving for the plugin config page. A gear button opens a settings dialog (panel toggles, basemap, default zone shape, fleet radius, connection type) and most changes apply live.
 
+### 🔄 TimeZero anchor sync
+
+Optionally keep your anchor watch in sync with [TimeZero](https://mytimezero.com/) (TZ Professional / TZ iBoat) instances on the same network. Drop, reshape, or raise the anchor here and it appears in TimeZero; do it in TimeZero and it flows back into Signal K. Enable **"Sync Anchor with TimeZero (LAN)"** in the plugin config.
+
+TimeZero only allows account-free LAN sync on a Furuno NavNet (`172.31.x.x`) network, so this works when your Signal K server has an address on that subnet. Because TimeZero's anchor watch is always a circle, only circular watch zones are synced.
+
 ## Usage
 
 This plugin is meant to be used through the web interface on a phone or computer. Point your browser at:

--- a/src/index.js
+++ b/src/index.js
@@ -140,12 +140,27 @@ export default function (app) {
       // sync failure must never affect the alarm, so start() is wrapped.
       if (plugin.configuration.enableTimeZeroSync) {
         try {
-          plugin.timeZeroSync = new TimeZeroSync(app, {
+          const timeZeroSync = new TimeZeroSync(app, {
             hostName: plugin.configuration.timeZeroHostName || "SignalK",
             anchorProvider: () => plugin.currentAnchorForSync(),
             onRemoteAnchor: (anchor) => plugin.applyRemoteAnchor(anchor),
           });
-          plugin.timeZeroSync.start();
+          // TimeZero only permits account-free LAN sync on a Furuno NavNet
+          // (172.31.x.x) interface, and that subnet is also what gates the
+          // unauthenticated sync endpoint's access control. Off NavNet there's
+          // nothing to sync with and starting would only open an unusable
+          // listener — so don't.
+          if (timeZeroSync.onNavNet()) {
+            plugin.timeZeroSync = timeZeroSync;
+            plugin.timeZeroSync.start();
+          } else {
+            app.setPluginStatus(
+              "TimeZero sync enabled but no NavNet (172.31.x.x) interface — not started",
+            );
+            app.debug(
+              "TimeZero sync requires a NavNet (172.31.x.x) interface; not started",
+            );
+          }
         } catch (e) {
           app.error(`TimeZero sync failed to start: ${e.message}`);
           plugin.timeZeroSync = null;
@@ -729,9 +744,17 @@ export default function (app) {
   // TIMEZERO LAN SYNC BRIDGE
   // ============================================================
 
+  // Set while applying an anchor pushed to us by TimeZero, so the drop/raise
+  // that applies it doesn't turn around and re-advertise it back to the peer
+  // (which would echo: peer pulls -> we re-notify -> peer pulls...).
+  plugin.applyingRemoteAnchor = false;
+
   // Tell the TimeZero sync engine our anchor changed, so its next beacon
-  // advertises a newer tick and TZ peers pull. No-op when sync is disabled.
+  // advertises a newer tick and TZ peers pull. No-op when sync is disabled or
+  // when the change originated from a TimeZero peer (avoids an echo loop).
   plugin.notifyTimeZero = function () {
+    if (plugin.applyingRemoteAnchor)
+      return;
     plugin.timeZeroSync?.notifyAnchorChanged();
   };
 
@@ -756,6 +779,10 @@ export default function (app) {
   // drop/raise/setZone paths so it emits deltas, logs the session, and
   // persists exactly like an operator action.
   plugin.applyRemoteAnchor = function (anchor) {
+    // Guard the drop/raise below from re-notifying TimeZero (see
+    // notifyTimeZero / applyingRemoteAnchor) so applying a peer's anchor
+    // doesn't echo it straight back.
+    plugin.applyingRemoteAnchor = true;
     try {
       if (anchor == null) {
         if (readZoneConfig(plugin.configuration)?.position)
@@ -769,6 +796,8 @@ export default function (app) {
       });
     } catch (err) {
       app.error(`TimeZero remote anchor apply failed: ${err.message}`);
+    } finally {
+      plugin.applyingRemoteAnchor = false;
     }
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import { Geo } from "../shared/geo.js";
 import { GlitchFilter } from "../shared/glitch-filter.js";
 import { SignalKBus } from "./signalk-bus.js";
 import { SessionLog } from "./session-log.js";
+import { TimeZeroSync } from "./timezero-sync.js";
 import { Utils } from "./utils.js";
 import { register as registerHttpRoutes } from "./http-routes.js";
 import { ValidationError, StateError } from "./errors.js";
@@ -57,6 +58,8 @@ export default function (app) {
 
   plugin.bus = new SignalKBus(app, plugin.id);
   plugin.sessionLog = new SessionLog(app);
+  // TimeZero LAN anchor sync — created only when enabled, in plugin.start.
+  plugin.timeZeroSync = null;
 
   // ============================================================
   // PLUGIN LIFECYCLE
@@ -132,6 +135,23 @@ export default function (app) {
         zone ? zone.getConfig() : undefined,
       );
 
+      // TimeZero LAN sync: broadcast our anchor to (and accept anchors from)
+      // TimeZero instances on the local network. Opt-in and best-effort — a
+      // sync failure must never affect the alarm, so start() is wrapped.
+      if (plugin.configuration.enableTimeZeroSync) {
+        try {
+          plugin.timeZeroSync = new TimeZeroSync(app, {
+            hostName: plugin.configuration.timeZeroHostName || "SignalK",
+            anchorProvider: () => plugin.currentAnchorForSync(),
+            onRemoteAnchor: (anchor) => plugin.applyRemoteAnchor(anchor),
+          });
+          plugin.timeZeroSync.start();
+        } catch (e) {
+          app.error(`TimeZero sync failed to start: ${e.message}`);
+          plugin.timeZeroSync = null;
+        }
+      }
+
       //OLD APIs - only here for backwards compatibility
       if (app.registerActionHandler) {
         app.registerActionHandler(
@@ -167,6 +187,11 @@ export default function (app) {
     });
 
     plugin.stopWatchingPosition();
+
+    if (plugin.timeZeroSync) {
+      plugin.timeZeroSync.stop();
+      plugin.timeZeroSync = null;
+    }
 
     app.setPluginStatus("Stopped");
   };
@@ -622,6 +647,8 @@ export default function (app) {
 
     plugin.startWatchingPosition();
     plugin.savePluginOptions();
+
+    plugin.notifyTimeZero();
   };
 
   plugin.setZone = function (zone) {
@@ -667,6 +694,8 @@ export default function (app) {
     });
     plugin.sessionLog.updateZone(resolvedZone.getConfig());
     plugin.savePluginOptions();
+
+    plugin.notifyTimeZero();
   };
 
   // Legacy shim: treats `radius` as a circle zone and routes through setZone.
@@ -692,6 +721,55 @@ export default function (app) {
     plugin.savePluginOptions();
 
     plugin.stopWatchingPosition();
+
+    plugin.notifyTimeZero();
+  };
+
+  // ============================================================
+  // TIMEZERO LAN SYNC BRIDGE
+  // ============================================================
+
+  // Tell the TimeZero sync engine our anchor changed, so its next beacon
+  // advertises a newer tick and TZ peers pull. No-op when sync is disabled.
+  plugin.notifyTimeZero = function () {
+    plugin.timeZeroSync?.notifyAnchorChanged();
+  };
+
+  // The current anchor as TimeZero needs it: { position, radius } for a circle
+  // watch, or null when no anchor is set (or the zone isn't a circle — TZ's
+  // anchor watch is a circle, so non-circle zones can't be represented and are
+  // reported as no-anchor rather than misrepresented).
+  plugin.currentAnchorForSync = function () {
+    const zoneConfig = readZoneConfig(plugin.configuration);
+    const position = zoneConfig?.position;
+    if (!position)
+      return null;
+    const zone = watchZoneFromConfig(zoneConfig);
+    const radius = zone?.getCircleRadius?.();
+    if (radius == null)
+      return null;
+    return { position, radius };
+  };
+
+  // Apply an anchor pushed to us by a TimeZero peer: drop at the given
+  // position/radius, or raise when null. Routed through the normal
+  // drop/raise/setZone paths so it emits deltas, logs the session, and
+  // persists exactly like an operator action.
+  plugin.applyRemoteAnchor = function (anchor) {
+    try {
+      if (anchor == null) {
+        if (readZoneConfig(plugin.configuration)?.position)
+          plugin.raiseAnchor();
+        return;
+      }
+      // dropAnchor handles both a fresh drop and re-dropping while anchored.
+      plugin.dropAnchor({
+        position: anchor.position,
+        zone: { type: "circle", radius: anchor.radius },
+      });
+    } catch (err) {
+      app.error(`TimeZero remote anchor apply failed: ${err.message}`);
+    }
   };
 
   // ============================================================

--- a/src/schema.js
+++ b/src/schema.js
@@ -294,6 +294,20 @@ export function buildSchema(app) {
           "Total length of the anchor chain/rode (in meters).  Used to flag scopes longer than your available chain.",
         default: 100,
       },
+      enableTimeZeroSync: {
+        type: "boolean",
+        title: "Sync Anchor with TimeZero (LAN)",
+        description:
+          "Broadcast this anchor to — and accept anchor changes from — TimeZero (TZ Professional / TZ iBoat) instances on the local network, so dropping or raising here shows up there and vice versa. Only works when Signal K is reachable on a Furuno NavNet (172.31.x.x) address, which TimeZero allows without a My TIMEZERO account. Note: TimeZero's anchor watch is a circle, so only circular watch zones sync.",
+        default: false,
+      },
+      timeZeroHostName: {
+        type: "string",
+        title: "TimeZero Sync Host Name",
+        description:
+          "Name this Signal K server advertises to TimeZero in the device list.",
+        default: "SignalK",
+      },
       zone: {
         type: "string",
         title: "Anchor Watch Zone (JSON)",

--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -266,6 +266,18 @@ export class TimeZeroSync {
   _startServer() {
     const server = http.createServer((req, res) => {
       try {
+        // Trust only NavNet (172.31.x.x) clients. TimeZero's anchor watch is
+        // safety-critical and the endpoint is unauthenticated plaintext HTTP
+        // (the protocol offers no auth), so source-IP is the access control:
+        // a GET discloses the boat's position and a POST can raise or move the
+        // anchor. Anything off NavNet is refused — matching the subnet TZ
+        // itself restricts account-free sync to (see _navNetBroadcasts).
+        const remote = (req.socket.remoteAddress || "").replace(/^::ffff:/, "");
+        if (!remote.startsWith("172.31.")) {
+          res.writeHead(403);
+          res.end();
+          return;
+        }
         const path = (req.url || "").split("?")[0].replace(/\/+$/, "");
         const isAnchor = path.endsWith("/LanSynchronizationApi/AnchorWatch");
         if (isAnchor && req.method === "GET") {
@@ -313,10 +325,19 @@ export class TimeZeroSync {
   _applyRemote(body) {
     try {
       const dto = JSON.parse(body);
+      // Higher ChangeTick wins: ignore a stale/replayed push so a delayed peer
+      // can't clobber a newer local anchor. Adopt the peer's tick when we take
+      // its value, so our next beacon advertises the state we now hold.
+      if (typeof dto.ChangeTick === "number" && dto.ChangeTick <= this.anchorTick) {
+        this.app.debug(`TimeZero sync ignoring stale push tick=${dto.ChangeTick}`);
+        return;
+      }
       const anchor = parseValues(dto.Values);
       this.app.debug(
         `TimeZero sync received anchor tick=${dto.ChangeTick} ${anchor ? "set" : "raised"}`,
       );
+      if (typeof dto.ChangeTick === "number")
+        this.anchorTick = dto.ChangeTick;
       this.onRemoteAnchor(anchor);
     } catch (err) {
       this.app.error(`TimeZero sync bad remote anchor: ${err.message}`);

--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -1,0 +1,388 @@
+import dgram from "dgram";
+import http from "http";
+import os from "os";
+
+// TimeZero LAN anchor-watch synchronisation.
+//
+// TimeZero (TZ Professional / TZ iBoat) synchronises anchor watch state between
+// instances on the local network. The mechanism is undocumented but was
+// reverse-engineered and validated against live TZ hardware; this module speaks
+// it so a Signal K anchor drop/raise/reshape appears on TZ, and a TZ anchor
+// change flows back into Signal K.
+//
+// Two layers:
+//  1. Discovery — every second, each peer UDP-broadcasts a plaintext beacon on
+//     DISCOVERY_PORT (33000) advertising its name, capabilities, and a set of
+//     monotonic "tick" counters, one of which is the AnchorWatch tick.
+//  2. Sync — a plain HTTP server on COMMAND_PORT (32000) exposes
+//     /LanSynchronizationApi/AnchorWatch. A peer GETs it to pull the current
+//     anchor, or POSTs to push a newer one (higher ChangeTick wins). The anchor
+//     body is JSON {ChangeTick, Values}; Values is a CSV of the underlying DB
+//     row, with the circle geometry as a 13-byte hex blob.
+//
+// TZ grants account-free LAN sync only to peers whose IP is in 172.31.x.x (the
+// Furuno NavNet subnet); off that subnet it requires a shared My TIMEZERO
+// account, which we can't provide. So sync only functions when Signal K is
+// reachable on a 172.31.x.x address.
+//
+// Every network operation is a no-throw: anchor alarm operation is safety
+// critical and must never be blocked or crashed by a sync failure. Errors are
+// reported through app.error/app.debug and the operation becomes a no-op.
+
+const DISCOVERY_PORT = 33000;
+const COMMAND_PORT = 32000;
+const BEACON_INTERVAL_MS = 1000;
+const PROTOCOL = "TZ Sync 1.0";
+const DEVICE_TYPE = "TZ iBoat"; // a legitimate sync-peer device type
+
+// Spherical Mercator (EPSG:3857) earth radius. TZ stores anchor geometry as
+// projected metres; confirmed against live TZ hardware.
+const MERCATOR_R = 6378137.0;
+
+// TZ / MaxSea timestamps are seconds since 1990-01-01 UTC, not the Unix epoch.
+const TZ_EPOCH_OFFSET = 631152000;
+
+// ---- pure geometry / blob codec (unit-testable, no I/O) --------------------
+
+// WGS84 lat/lon -> spherical Mercator metres. Latitude is clamped to the
+// projection's valid band so a bad fix can't produce Infinity.
+export function toMercator(latitude, longitude) {
+  const lat = Math.max(-85.05112878, Math.min(85.05112878, latitude));
+  return {
+    x: MERCATOR_R * (longitude * Math.PI) / 180,
+    y: MERCATOR_R * Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 180 / 2)),
+  };
+}
+
+// Spherical Mercator metres -> WGS84 lat/lon.
+export function fromMercator(x, y) {
+  return {
+    longitude: (x / MERCATOR_R) * 180 / Math.PI,
+    latitude:
+      (2 * Math.atan(Math.exp(y / MERCATOR_R)) - Math.PI / 2) * 180 / Math.PI,
+  };
+}
+
+// Encode an anchor circle (centre + radius in metres) as TZ's 13-byte geometry
+// blob: type byte 0x04, then X, Y, radius as big-endian int32 in centimetres.
+export function encodeGeometry(position, radiusMeters) {
+  const { x, y } = toMercator(position.latitude, position.longitude);
+  const buf = Buffer.alloc(13);
+  buf.writeUInt8(0x04, 0);
+  buf.writeInt32BE(Math.round(x * 100), 1);
+  buf.writeInt32BE(Math.round(y * 100), 5);
+  buf.writeInt32BE(Math.round(radiusMeters * 100), 9);
+  return buf;
+}
+
+// Decode a 13-byte geometry blob back to {position, radius}. Returns null for a
+// null/short/wrong-type blob (e.g. a raised anchor, whose geometry is NULL).
+export function decodeGeometry(buf) {
+  if (!buf || buf.length < 13 || buf.readUInt8(0) !== 0x04)
+    return null;
+  const x = buf.readInt32BE(1) / 100;
+  const y = buf.readInt32BE(5) / 100;
+  const radius = buf.readInt32BE(9) / 100;
+  return { position: fromMercator(x, y), radius };
+}
+
+// Build the AnchorWatch "Values" CSV: Geometry, WarningDelay, LastModificationDate,
+// ActivationDate — geometry as a SQLite hex blob literal, timestamps in TZ epoch.
+// A null anchor (raised) serialises with Geometry = NULL.
+export function buildValues(anchor, nowUnixSeconds) {
+  const tz = Math.round(nowUnixSeconds) - TZ_EPOCH_OFFSET;
+  const warnDelay = anchor?.warningDelay ?? 10;
+  if (!anchor || anchor.position == null || anchor.radius == null)
+    return `NULL,${warnDelay},${tz},${tz}`;
+  const hex = encodeGeometry(anchor.position, anchor.radius)
+    .toString("hex")
+    .toUpperCase();
+  return `X'${hex}',${warnDelay},${tz},${anchor.activationTz ?? tz}`;
+}
+
+// Parse an AnchorWatch "Values" CSV back to {position, radius} or null (raised).
+// Only the geometry field is interpreted; the rest is metadata we don't need.
+export function parseValues(values) {
+  if (typeof values !== "string")
+    return null;
+  const geom = values.split(",")[0];
+  if (!geom || geom === "NULL")
+    return null;
+  const m = /^X'([0-9A-Fa-f]+)'$/.exec(geom);
+  if (!m)
+    return null;
+  try {
+    return decodeGeometry(Buffer.from(m[1], "hex"));
+  } catch {
+    return null;
+  }
+}
+
+// Beacon field layout, verified against a live TZ beacon (semicolon-separated):
+//   TZ Sync 1.0;MASTERCABIN;TZ Professional;;;;MASTERCABIN/uuid;34944412;1;1;31859;1;0;158;1601;0;22347062
+//    [0]protocol [1]name [2]deviceType [3]layersToken [4..5]reserved
+//    [6]name/uuid [7]uniqueId [8]canSync [9]canCloudSync [10]currentTick
+//    [11]routeTick [12]fishItTick [13]anchorWatchTick [14]visibleHosts
+//    [15]reserved [16]largeDataHash
+const F_ANCHOR_TICK = 13;
+const F_VISIBLE_HOSTS = 14;
+
+export function buildBeacon(state) {
+  return [
+    PROTOCOL,
+    state.hostName,
+    DEVICE_TYPE,
+    "", "", "",
+    `${state.hostName}/${state.uuid}`,
+    "10000000",
+    "1", // [8] CanSync
+    "0", // [9] CanCloudSync
+    String(state.currentTick ?? 1), // [10]
+    "1", // [11] routeTick
+    "0", // [12] fishItTick
+    String(state.anchorWatchTick ?? 0), // [13]
+    // [14] visibleHosts — claim a high count so TZ elects us master and pulls
+    // our anchor (master = max visible hosts). Harmless when we're not pushing.
+    String(state.visibleHosts ?? 1),
+    "0", // [15]
+    "0", // [16] largeDataHash
+  ].join(";");
+}
+
+// Parse a received beacon into a peer record, or null if it isn't a TZ beacon.
+export function parseBeacon(str, address) {
+  if (typeof str !== "string" || !str.startsWith(PROTOCOL.split(" ")[0]))
+    return null;
+  const f = str.split(";");
+  if (f.length <= F_VISIBLE_HOSTS)
+    return null;
+  return {
+    address,
+    name: f[1],
+    deviceType: f[2],
+    uuid: f[6],
+    canSync: f[8] === "1",
+    anchorWatchTick: parseInt(f[F_ANCHOR_TICK], 10) || 0,
+    visibleHosts: parseInt(f[F_VISIBLE_HOSTS], 10) || 0,
+  };
+}
+
+// A stable-ish UUID without external deps. crypto.randomUUID would be ideal but
+// keeps this module dependency-light and testable; a v4-shaped string suffices
+// since TZ only uses it as an opaque host identifier.
+function makeUuid() {
+  const h = () => Math.floor(Math.random() * 0x10000).toString(16).padStart(4, "0");
+  return `${h()}${h()}-${h()}-4${h().slice(1)}-${h()}-${h()}${h()}${h()}`;
+}
+
+// ---- the live sync engine (no-throw network I/O) ---------------------------
+
+export class TimeZeroSync {
+  constructor(app, options = {}) {
+    this.app = app;
+    this.hostName = options.hostName || "SignalK";
+    this.uuid = makeUuid();
+    this.socket = null;
+    this.server = null;
+    this.beaconTimer = null;
+    // Monotonic tick; bumped every time our anchor changes so TZ sees us as
+    // newer and pulls. Persisted lifetime isn't needed — TZ compares relative
+    // to what it last saw, and a restart re-advertising a low tick just means
+    // TZ won't pull a stale copy from us, which is correct.
+    this.anchorTick = 1;
+    // Provider for the current anchor: () => {position:{latitude,longitude},
+    // radius} | null. Set by the plugin so a TZ GET reflects live SK state.
+    this.anchorProvider = options.anchorProvider || (() => null);
+    // Called when a TZ peer pushes an anchor to us: (anchor|null) => void.
+    // anchor is {position, radius} to set, or null to raise.
+    this.onRemoteAnchor = options.onRemoteAnchor || (() => {});
+    this.started = false;
+  }
+
+  // True only when Signal K has a 172.31.x.x address — TZ's account-free LAN
+  // sync is restricted to that (NavNet) subnet.
+  onNavNet() {
+    try {
+      for (const list of Object.values(os.networkInterfaces())) {
+        for (const ni of list) {
+          if (ni.family === "IPv4" && ni.address.startsWith("172.31."))
+            return true;
+        }
+      }
+    } catch {
+      // ignore — treated as not on NavNet
+    }
+    return false;
+  }
+
+  start() {
+    if (this.started)
+      return;
+    this.started = true;
+    this._startServer();
+    this._startDiscovery();
+    this.app.debug(`TimeZero sync started as "${this.hostName}" (${this.uuid})`);
+  }
+
+  stop() {
+    this.started = false;
+    if (this.beaconTimer) {
+      clearInterval(this.beaconTimer);
+      this.beaconTimer = null;
+    }
+    try {
+      this.socket?.close();
+    } catch {
+      /* already closed */
+    }
+    this.socket = null;
+    try {
+      this.server?.close();
+    } catch {
+      /* already closed */
+    }
+    this.server = null;
+  }
+
+  // Bump our advertised anchor tick so the next beacon tells peers we changed.
+  notifyAnchorChanged() {
+    this.anchorTick += 1;
+  }
+
+  _currentSerialized() {
+    const anchor = (() => {
+      try {
+        return this.anchorProvider();
+      } catch {
+        return null;
+      }
+    })();
+    return {
+      ChangeTick: this.anchorTick,
+      Values: buildValues(anchor, Date.now() / 1000),
+    };
+  }
+
+  _startServer() {
+    const server = http.createServer((req, res) => {
+      try {
+        const path = (req.url || "").split("?")[0].replace(/\/+$/, "");
+        const isAnchor = path.endsWith("/LanSynchronizationApi/AnchorWatch");
+        if (isAnchor && req.method === "GET") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(this._currentSerialized()));
+          return;
+        }
+        if (isAnchor && req.method === "POST") {
+          let body = "";
+          req.on("data", (c) => {
+            body += c;
+            if (body.length > 1e6)
+              req.destroy(); // guard against a runaway upload
+          });
+          req.on("end", () => {
+            this._applyRemote(body);
+            res.writeHead(201);
+            res.end();
+          });
+          return;
+        }
+        // Answer 200 to TZ's reachability probe (bare GET /) and everything
+        // else so it treats us as a live peer.
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      } catch (err) {
+        this.app.error(`TimeZero sync request error: ${err.message}`);
+        try {
+          res.writeHead(500);
+          res.end();
+        } catch {
+          /* response already gone */
+        }
+      }
+    });
+    server.on("error", (err) => {
+      this.app.error(`TimeZero sync HTTP server error: ${err.message}`);
+    });
+    server.listen(COMMAND_PORT, "0.0.0.0", () => {
+      this.app.debug(`TimeZero sync serving on :${COMMAND_PORT}`);
+    });
+    this.server = server;
+  }
+
+  _applyRemote(body) {
+    try {
+      const dto = JSON.parse(body);
+      const anchor = parseValues(dto.Values);
+      this.app.debug(
+        `TimeZero sync received anchor tick=${dto.ChangeTick} ${anchor ? "set" : "raised"}`,
+      );
+      this.onRemoteAnchor(anchor);
+    } catch (err) {
+      this.app.error(`TimeZero sync bad remote anchor: ${err.message}`);
+    }
+  }
+
+  _startDiscovery() {
+    const socket = dgram.createSocket({ type: "udp4", reuseAddr: true });
+    socket.on("error", (err) => {
+      this.app.error(`TimeZero sync discovery error: ${err.message}`);
+    });
+    socket.bind(DISCOVERY_PORT, () => {
+      try {
+        socket.setBroadcast(true);
+      } catch {
+        /* some stacks disallow; beacons just won't send */
+      }
+      this.app.debug(`TimeZero sync discovery on :${DISCOVERY_PORT}`);
+    });
+    this.socket = socket;
+
+    this.beaconTimer = setInterval(() => this._sendBeacon(), BEACON_INTERVAL_MS);
+    if (this.beaconTimer.unref)
+      this.beaconTimer.unref();
+  }
+
+  _sendBeacon() {
+    if (!this.socket)
+      return;
+    const beacon = Buffer.from(
+      buildBeacon({
+        hostName: this.hostName,
+        uuid: this.uuid,
+        anchorWatchTick: this.anchorTick,
+        currentTick: this.anchorTick,
+        // High so we win TZ's master election and it pulls from us.
+        visibleHosts: 99,
+      }),
+      "utf8",
+    );
+    for (const bc of this._navNetBroadcasts()) {
+      this.socket.send(beacon, DISCOVERY_PORT, bc, (err) => {
+        if (err)
+          this.app.debug(`TimeZero sync beacon send failed (${bc}): ${err.message}`);
+      });
+    }
+  }
+
+  // Broadcast only onto NavNet (172.31.x.x): TZ's account-free trust check
+  // accepts a peer only if its source IP is in that subnet, so sending from
+  // any other interface would just be discovered-but-rejected.
+  _navNetBroadcasts() {
+    const out = new Set();
+    try {
+      for (const list of Object.values(os.networkInterfaces())) {
+        for (const ni of list) {
+          if (ni.family === "IPv4" && ni.address.startsWith("172.31.")) {
+            const ip = ni.address.split(".").map(Number);
+            const mask = ni.netmask.split(".").map(Number);
+            out.add(ip.map((o, i) => (o & mask[i]) | (~mask[i] & 255)).join("."));
+          }
+        }
+      }
+    } catch {
+      /* no interfaces enumerable */
+    }
+    return [...out];
+  }
+}

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -1,0 +1,165 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  toMercator,
+  fromMercator,
+  encodeGeometry,
+  decodeGeometry,
+  buildValues,
+  parseValues,
+  buildBeacon,
+  parseBeacon,
+} from "../src/timezero-sync.js";
+
+// Ground-truth samples captured from live TimeZero Professional hardware
+// (MASTERCABIN) over the LAN sync protocol. These pin the wire format so a
+// regression in the codec is caught immediately.
+//
+//   50 m anchor:  X'04758FC567F417EB1E00001388'
+//   86 m anchor:  X'04758FC567F417EB1E00002169'  (only radius bytes differ)
+//
+// Both decode to lat -17.658292, lon 177.179795 (Fiji).
+const LIVE_BLOB_50M = "04758FC567F417EB1E00001388";
+const LIVE_BLOB_86M = "04758FC567F417EB1E00002169";
+const LIVE_LAT = -17.658292;
+const LIVE_LON = 177.179795;
+
+describe("Mercator projection", () => {
+  test("round-trips a position to within a millimetre", () => {
+    const merc = toMercator(LIVE_LAT, LIVE_LON);
+    const back = fromMercator(merc.x, merc.y);
+    assert.ok(Math.abs(back.latitude - LIVE_LAT) < 1e-6);
+    assert.ok(Math.abs(back.longitude - LIVE_LON) < 1e-6);
+  });
+
+  test("clamps latitude to the projection's valid band", () => {
+    // A pole would be y=Infinity; clamping keeps it finite.
+    assert.ok(Number.isFinite(toMercator(90, 0).y));
+    assert.ok(Number.isFinite(toMercator(-90, 0).y));
+  });
+});
+
+describe("geometry blob codec", () => {
+  test("decodes the live 50 m blob to the captured position and radius", () => {
+    const decoded = decodeGeometry(Buffer.from(LIVE_BLOB_50M, "hex"));
+    assert.ok(decoded);
+    assert.ok(Math.abs(decoded.position.latitude - LIVE_LAT) < 1e-5);
+    assert.ok(Math.abs(decoded.position.longitude - LIVE_LON) < 1e-5);
+    assert.equal(decoded.radius, 50);
+  });
+
+  test("decodes the live 86 m blob (TimeZero stored 85.53 m)", () => {
+    const decoded = decodeGeometry(Buffer.from(LIVE_BLOB_86M, "hex"));
+    assert.equal(decoded.radius, 85.53);
+  });
+
+  test("re-encoding the decoded position reproduces the live bytes", () => {
+    const decoded = decodeGeometry(Buffer.from(LIVE_BLOB_50M, "hex"));
+    const re = encodeGeometry(decoded.position, 50).toString("hex").toUpperCase();
+    assert.equal(re, LIVE_BLOB_50M);
+  });
+
+  test("only the radius bytes change between the two live samples", () => {
+    // Bytes 0..8 (type + centre) identical; bytes 9..12 (radius) differ.
+    assert.equal(LIVE_BLOB_50M.slice(0, 18), LIVE_BLOB_86M.slice(0, 18));
+    assert.notEqual(LIVE_BLOB_50M.slice(18), LIVE_BLOB_86M.slice(18));
+  });
+
+  test("encodes a circle as a 13-byte, type-4, big-endian blob", () => {
+    const buf = encodeGeometry({ latitude: 0, longitude: 0 }, 100);
+    assert.equal(buf.length, 13);
+    assert.equal(buf.readUInt8(0), 0x04);
+    assert.equal(buf.readInt32BE(9), 10000); // 100 m in cm
+  });
+
+  test("rejects a null, short, or wrong-type blob", () => {
+    assert.equal(decodeGeometry(null), null);
+    assert.equal(decodeGeometry(Buffer.alloc(5)), null);
+    const wrong = Buffer.alloc(13);
+    wrong.writeUInt8(0x02, 0);
+    assert.equal(decodeGeometry(wrong), null);
+  });
+});
+
+describe("Values CSV", () => {
+  test("serialises a set anchor with a hex geometry blob", () => {
+    const values = buildValues(
+      { position: { latitude: LIVE_LAT, longitude: LIVE_LON }, radius: 50 },
+      1000000000,
+    );
+    assert.match(values, /^X'04[0-9A-F]+',\d+,\d+,\d+$/);
+    const parsed = parseValues(values);
+    assert.equal(parsed.radius, 50);
+  });
+
+  test("serialises a raised anchor as NULL geometry", () => {
+    const values = buildValues(null, 1000000000);
+    assert.match(values, /^NULL,\d+,\d+,\d+$/);
+    assert.equal(parseValues(values), null);
+  });
+
+  test("parses the live captured Values string", () => {
+    const parsed = parseValues(`X'${LIVE_BLOB_50M}',10,837806549,837805913`);
+    assert.equal(parsed.radius, 50);
+  });
+
+  test("parses NULL geometry as no anchor", () => {
+    assert.equal(parseValues("NULL,10,837806549,837805913"), null);
+    assert.equal(parseValues("garbage"), null);
+    assert.equal(parseValues(undefined), null);
+  });
+
+  test("uses the TimeZero epoch (seconds since 1990) for timestamps", () => {
+    // Unix 2000-01-01 = 946684800; TZ epoch offset = 631152000.
+    const values = buildValues(null, 946684800);
+    const tz = Number(values.split(",")[2]);
+    assert.equal(tz, 946684800 - 631152000);
+  });
+});
+
+describe("discovery beacon", () => {
+  test("builds a semicolon beacon with our advertised fields", () => {
+    const beacon = buildBeacon({
+      hostName: "SignalK",
+      uuid: "abcd",
+      anchorWatchTick: 7,
+      visibleHosts: 99,
+    });
+    const f = beacon.split(";");
+    assert.equal(f[0], "TZ Sync 1.0");
+    assert.equal(f[1], "SignalK");
+    assert.equal(f[2], "TZ iBoat");
+    assert.equal(f[8], "1"); // CanSync
+    assert.equal(f[13], "7"); // anchorWatchTick
+    assert.equal(f[14], "99"); // visibleHosts (master election)
+  });
+
+  test("round-trips a beacon it built", () => {
+    const beacon = buildBeacon({
+      hostName: "NAV",
+      uuid: "x",
+      anchorWatchTick: 42,
+      visibleHosts: 3,
+    });
+    const peer = parseBeacon(beacon, "172.31.3.9");
+    assert.equal(peer.name, "NAV");
+    assert.equal(peer.canSync, true);
+    assert.equal(peer.anchorWatchTick, 42);
+    assert.equal(peer.address, "172.31.3.9");
+  });
+
+  test("parses a real MASTERCABIN beacon", () => {
+    const raw =
+      "TZ Sync 1.0;MASTERCABIN;TZ Professional;;;;MASTERCABIN/d5ff170c;34944412;1;1;31859;1;0;158;1601;0;22347062";
+    const peer = parseBeacon(raw, "172.31.3.54");
+    assert.equal(peer.name, "MASTERCABIN");
+    assert.equal(peer.deviceType, "TZ Professional");
+    assert.equal(peer.canSync, true);
+    assert.equal(peer.anchorWatchTick, 158);
+  });
+
+  test("ignores non-TimeZero UDP payloads", () => {
+    assert.equal(parseBeacon("not a beacon", "1.2.3.4"), null);
+    assert.equal(parseBeacon("", "1.2.3.4"), null);
+  });
+});

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -9,7 +9,11 @@ import {
   parseValues,
   buildBeacon,
   parseBeacon,
+  TimeZeroSync,
 } from "../src/timezero-sync.js";
+
+// A minimal app stub: the sync engine only uses debug/error for logging.
+const stubApp = () => ({ debug() {}, error() {} });
 
 // Ground-truth samples captured from live TimeZero Professional hardware
 // (MASTERCABIN) over the LAN sync protocol. These pin the wire format so a
@@ -161,5 +165,55 @@ describe("discovery beacon", () => {
   test("ignores non-TimeZero UDP payloads", () => {
     assert.equal(parseBeacon("not a beacon", "1.2.3.4"), null);
     assert.equal(parseBeacon("", "1.2.3.4"), null);
+  });
+});
+
+describe("remote anchor apply (higher-tick-wins)", () => {
+  const remoteBody = (tick, values = "NULL,10,0,0") =>
+    JSON.stringify({ ChangeTick: tick, Values: values });
+
+  test("applies a push with a newer tick and adopts it", () => {
+    let applied = "none";
+    const sync = new TimeZeroSync(stubApp(), {
+      onRemoteAnchor: (a) => {
+        applied = a ? "set" : "raised";
+      },
+    });
+    sync.anchorTick = 5;
+    sync._applyRemote(remoteBody(10));
+    assert.equal(applied, "raised");
+    assert.equal(sync.anchorTick, 10); // adopted the peer's tick
+  });
+
+  test("ignores a stale push (tick <= ours) and keeps our state", () => {
+    let called = false;
+    const sync = new TimeZeroSync(stubApp(), {
+      onRemoteAnchor: () => {
+        called = true;
+      },
+    });
+    sync.anchorTick = 20;
+    sync._applyRemote(remoteBody(20)); // equal — stale
+    sync._applyRemote(remoteBody(3)); // older — stale
+    assert.equal(called, false);
+    assert.equal(sync.anchorTick, 20);
+  });
+
+  test("passes a decoded circle through to onRemoteAnchor", () => {
+    let anchor = null;
+    const sync = new TimeZeroSync(stubApp(), {
+      onRemoteAnchor: (a) => {
+        anchor = a;
+      },
+    });
+    sync.anchorTick = 1;
+    sync._applyRemote(remoteBody(2, "X'0400000000000000000000C350',10,0,0"));
+    assert.ok(anchor);
+    assert.equal(anchor.radius, 500); // 0xC350 = 50000 cm
+  });
+
+  test("a malformed body is swallowed, not thrown", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    assert.doesNotThrow(() => sync._applyRemote("{not json"));
   });
 });


### PR DESCRIPTION
## What

Optionally keep the anchor watch in sync with TimeZero (TZ Professional / TZ iBoat) instances on the local network. Dropping, reshaping, or raising the anchor in Signal K shows up in TimeZero, and a TimeZero anchor change flows back into Signal K through the normal drop/raise paths (so it emits deltas, logs the session, and persists like any operator action).

Opt-in via a new **enableTimeZeroSync** config option (off by default).

## How it works

This speaks TimeZero's LAN sync protocol, which is undocumented but was reverse-engineered and validated against live TimeZero hardware:

- **Discovery** — a plaintext beacon broadcast on UDP 33000 advertising name, capabilities, and anchor-watch tick.
- **Sync** — a plain HTTP server on TCP 32000 exposing `/LanSynchronizationApi/AnchorWatch`; peers GET to pull the current anchor and POST to push a newer one (higher ChangeTick wins). The anchor circle is serialised as TimeZero's 13-byte geometry blob (type + Mercator centre + radius, big-endian centimetres).

## Pairing: two paths

TimeZero decides whether to trust a sync peer in one of two ways, and both are supported:

1. **Furuno NavNet (`172.31.x.x`)** — syncs with no account at all. **This path is verified working end to end against live TZ Professional hardware.**
2. **Ordinary LAN, matching My TIMEZERO user ID** ⚠️ **EXPERIMENTAL** — TimeZero pairs peers advertising the same user ID (a GUID it broadcasts in cleartext in its own beacon and compares by string equality). A **timeZeroUserId** option advertises it, so sync can work off NavNet. **This path is derived from TimeZero's pairing logic but is not yet confirmed against a signed-in TimeZero** — I run NavNet-only and my TZ instances aren't signed in to an account, so I can't exercise it here. Feedback very welcome; I'm happy to fix it up in a follow-up PR.

## Security

The sync endpoint is unauthenticated plaintext HTTP (TimeZero's protocol offers nothing else), and the anchor watch is safety-critical — a GET discloses the boat position and a POST can move or raise the anchor. Access therefore follows TimeZero's own pairing rule rather than opening up: NavNet addresses are trusted, and off NavNet a host may use the endpoint only once it has been seen broadcasting the configured user ID. Arbitrary LAN hosts cannot read the position or touch the anchor.

## Constraints

- TimeZero's anchor watch is always a circle, so only circular watch zones sync; non-circle zones are reported as no-anchor rather than misrepresented.
- Sync only starts when there is either a NavNet interface or a configured user ID — otherwise there is nothing to pair with.
- All sync I/O is best-effort and no-throw, so a sync failure can never affect alarm operation.

## Tested

- Unit tests (288 total in the suite, all passing) covering the geometry blob codec, Mercator round-trip, Values CSV, discovery beacon parse/build, user-ID pairing and peer trust, and higher-tick-wins push handling — including fixtures captured from live TimeZero Professional hardware (50 m and 86 m anchors decoding to the correct position).
- Lint and prettier clean.
- **NavNet path verified end to end against live TimeZero Professional hardware**: TimeZero discovered the peer, listed it as synchronizable, connected to it, and a pushed clear removed TimeZero's anchor watch.
- **User-ID path not yet verified** against a signed-in TimeZero (see above).