### PR TITLE
feat: pair with TimeZero by My TIMEZERO user ID off NavNet (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ Optionally keep your anchor watch in sync with [TimeZero](https://mytimezero.com
 TimeZero pairs peers in one of two ways:
 
 - **On a Furuno NavNet (`172.31.x.x`) network** it syncs without an account — just enable the option.
-- **On an ordinary LAN** it only pairs with peers advertising the same My TIMEZERO user ID, which requires your TimeZero instances to be signed in to a My TIMEZERO account. Set **"My TIMEZERO User ID"** to the ID they use and they will sync here too. It is a GUID (e.g. `d5ff170c-4a28-47e0-b54f-1f98bda46c1c`), not your email address. TimeZero broadcasts it in the clear on UDP port 33000, so you can read it from a signed-in TimeZero machine's own beacon — field 5 of the semicolon-separated `TZ Sync` message:
+- **On an ordinary LAN** (⚠️ _experimental_) it only pairs with peers advertising the same My TIMEZERO user ID, which requires your TimeZero instances to be signed in to a My TIMEZERO account. Set **"My TIMEZERO User ID"** to the ID they use and they should sync here too. It is a GUID (e.g. `d5ff170c-4a28-47e0-b54f-1f98bda46c1c`), not your email address. TimeZero broadcasts it in the clear on UDP port 33000, so you can read it from a signed-in TimeZero machine's own beacon — field 5 of the semicolon-separated `TZ Sync` message:
 
   ```
   tcpdump -i any -A udp port 33000
   ```
+
+  This path is derived from TimeZero's own pairing logic but has not yet been confirmed against a signed-in TimeZero, so treat it as experimental and please report what you find.
 
 Because TimeZero's anchor watch is always a circle, only circular watch zones are synced.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Logged-in users can tweak the UI without leaving for the plugin config page. A g
 
 Optionally keep your anchor watch in sync with [TimeZero](https://mytimezero.com/) (TZ Professional / TZ iBoat) instances on the same network. Drop, reshape, or raise the anchor here and it appears in TimeZero; do it in TimeZero and it flows back into Signal K. Enable **"Sync Anchor with TimeZero (LAN)"** in the plugin config.
 
-TimeZero only allows account-free LAN sync on a Furuno NavNet (`172.31.x.x`) network, so this works when your Signal K server has an address on that subnet. Because TimeZero's anchor watch is always a circle, only circular watch zones are synced.
+TimeZero pairs peers in one of two ways:
+
+- **On a Furuno NavNet (`172.31.x.x`) network** it syncs without an account — just enable the option.
+- **On an ordinary LAN** it only pairs with peers advertising the same My TIMEZERO user ID. Set **"My TIMEZERO User ID"** to the ID your TimeZero instances use and they will sync here too. TimeZero broadcasts this ID in the clear on UDP port 33000, so you can read it from a TimeZero machine's own beacon (field 5 of the semicolon-separated `TZ Sync` message).
+
+Because TimeZero's anchor watch is always a circle, only circular watch zones are synced.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ Optionally keep your anchor watch in sync with [TimeZero](https://mytimezero.com
 TimeZero pairs peers in one of two ways:
 
 - **On a Furuno NavNet (`172.31.x.x`) network** it syncs without an account — just enable the option.
-- **On an ordinary LAN** it only pairs with peers advertising the same My TIMEZERO user ID. Set **"My TIMEZERO User ID"** to the ID your TimeZero instances use and they will sync here too. TimeZero broadcasts this ID in the clear on UDP port 33000, so you can read it from a TimeZero machine's own beacon (field 5 of the semicolon-separated `TZ Sync` message).
+- **On an ordinary LAN** it only pairs with peers advertising the same My TIMEZERO user ID, which requires your TimeZero instances to be signed in to a My TIMEZERO account. Set **"My TIMEZERO User ID"** to the ID they use and they will sync here too. It is a GUID (e.g. `d5ff170c-4a28-47e0-b54f-1f98bda46c1c`), not your email address. TimeZero broadcasts it in the clear on UDP port 33000, so you can read it from a signed-in TimeZero machine's own beacon — field 5 of the semicolon-separated `TZ Sync` message:
+
+  ```
+  tcpdump -i any -A udp port 33000
+  ```
 
 Because TimeZero's anchor watch is always a circle, only circular watch zones are synced.
 

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,10 @@ export default function (app) {
           if (timeZeroSync.onNavNet() || userId) {
             plugin.timeZeroSync = timeZeroSync;
             plugin.timeZeroSync.start();
+            if (!timeZeroSync.onNavNet())
+              app.debug(
+                "TimeZero sync pairing by My TIMEZERO user ID (experimental — no NavNet interface found)",
+              );
           } else {
             app.setPluginStatus(
               "TimeZero sync enabled but no NavNet interface and no user ID — not started",

--- a/src/index.js
+++ b/src/index.js
@@ -140,25 +140,26 @@ export default function (app) {
       // sync failure must never affect the alarm, so start() is wrapped.
       if (plugin.configuration.enableTimeZeroSync) {
         try {
+          const userId = (plugin.configuration.timeZeroUserId || "").trim();
           const timeZeroSync = new TimeZeroSync(app, {
             hostName: plugin.configuration.timeZeroHostName || "SignalK",
+            userId: userId,
             anchorProvider: () => plugin.currentAnchorForSync(),
             onRemoteAnchor: (anchor) => plugin.applyRemoteAnchor(anchor),
           });
-          // TimeZero only permits account-free LAN sync on a Furuno NavNet
-          // (172.31.x.x) interface, and that subnet is also what gates the
-          // unauthenticated sync endpoint's access control. Off NavNet there's
-          // nothing to sync with and starting would only open an unusable
-          // listener — so don't.
-          if (timeZeroSync.onNavNet()) {
+          // TimeZero pairs peers either by subnet — it syncs freely within a
+          // Furuno NavNet (172.31.x.x) — or by a shared My TIMEZERO user id.
+          // With neither there is nothing we can sync with, so starting would
+          // only open an unusable listener.
+          if (timeZeroSync.onNavNet() || userId) {
             plugin.timeZeroSync = timeZeroSync;
             plugin.timeZeroSync.start();
           } else {
             app.setPluginStatus(
-              "TimeZero sync enabled but no NavNet (172.31.x.x) interface — not started",
+              "TimeZero sync enabled but no NavNet interface and no user ID — not started",
             );
             app.debug(
-              "TimeZero sync requires a NavNet (172.31.x.x) interface; not started",
+              "TimeZero sync needs a NavNet (172.31.x.x) interface or a My TIMEZERO user ID; not started",
             );
           }
         } catch (e) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -319,7 +319,7 @@ export function buildSchema(app) {
         type: "string",
         title: "My TIMEZERO User ID (for non-NavNet networks)",
         description:
-          "Leave blank on a Furuno NavNet (172.31.x.x) network. On an ordinary LAN, TimeZero only pairs with peers advertising the same My TIMEZERO user ID, so set it to the ID your TimeZero instances use and they will sync here too. TimeZero broadcasts this ID in the clear on UDP port 33000 — you can read it from a TimeZero machine's own beacon (field 5 of the semicolon-separated 'TZ Sync' message).",
+          "Leave blank on a Furuno NavNet (172.31.x.x) network. On an ordinary LAN, TimeZero only pairs with peers advertising the same My TIMEZERO user ID, so set it to the ID your TimeZero instances use and they will sync here too. It is a GUID (e.g. d5ff170c-4a28-47e0-b54f-1f98bda46c1c), not your email address, and only appears once TimeZero is signed in to a My TIMEZERO account. TimeZero broadcasts it in the clear on UDP port 33000, so you can read it from a signed-in TimeZero machine's own beacon (field 5 of the semicolon-separated 'TZ Sync' message).",
         default: "",
       },
       zone: {

--- a/src/schema.js
+++ b/src/schema.js
@@ -317,9 +317,9 @@ export function buildSchema(app) {
       },
       timeZeroUserId: {
         type: "string",
-        title: "My TIMEZERO User ID (for non-NavNet networks)",
+        title: "⚠️ EXPERIMENTAL — My TIMEZERO User ID (for non-NavNet networks)",
         description:
-          "Leave blank on a Furuno NavNet (172.31.x.x) network. On an ordinary LAN, TimeZero only pairs with peers advertising the same My TIMEZERO user ID, so set it to the ID your TimeZero instances use and they will sync here too. It is a GUID (e.g. d5ff170c-4a28-47e0-b54f-1f98bda46c1c), not your email address, and only appears once TimeZero is signed in to a My TIMEZERO account. TimeZero broadcasts it in the clear on UDP port 33000, so you can read it from a signed-in TimeZero machine's own beacon (field 5 of the semicolon-separated 'TZ Sync' message).",
+          "⚠️ Experimental and untested against a signed-in TimeZero — feedback welcome. Leave blank on a Furuno NavNet (172.31.x.x) network, where sync is verified working. On an ordinary LAN, TimeZero only pairs with peers advertising the same My TIMEZERO user ID, so set it to the ID your TimeZero instances use and they should sync here too. It is a GUID (e.g. d5ff170c-4a28-47e0-b54f-1f98bda46c1c), not your email address, and only appears once TimeZero is signed in to a My TIMEZERO account. TimeZero broadcasts it in the clear on UDP port 33000, so you can read it from a signed-in TimeZero machine's own beacon (field 5 of the semicolon-separated 'TZ Sync' message).",
         default: "",
       },
       zone: {

--- a/src/schema.js
+++ b/src/schema.js
@@ -315,6 +315,13 @@ export function buildSchema(app) {
           "Name this Signal K server advertises to TimeZero in the device list.",
         default: "SignalK",
       },
+      timeZeroUserId: {
+        type: "string",
+        title: "My TIMEZERO User ID (for non-NavNet networks)",
+        description:
+          "Leave blank on a Furuno NavNet (172.31.x.x) network. On an ordinary LAN, TimeZero only pairs with peers advertising the same My TIMEZERO user ID, so set it to the ID your TimeZero instances use and they will sync here too. TimeZero broadcasts this ID in the clear on UDP port 33000 — you can read it from a TimeZero machine's own beacon (field 5 of the semicolon-separated 'TZ Sync' message).",
+        default: "",
+      },
       zone: {
         type: "string",
         title: "Anchor Watch Zone (JSON)",

--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -132,7 +132,12 @@ export function buildBeacon(state) {
     PROTOCOL,
     state.hostName,
     DEVICE_TYPE,
-    "", "", "",
+    "", // [3] layers token
+    // [4] My TIMEZERO user id. TimeZero grants sync to a peer advertising the
+    // same non-empty user id (plain string equality), which is what makes sync
+    // work off the NavNet subnet. Empty falls back to the NavNet-only path.
+    state.userId || "",
+    "", // [5] cloud token
     `${state.hostName}/${state.uuid}`,
     "10000000",
     "1", // [8] CanSync
@@ -160,6 +165,7 @@ export function parseBeacon(str, address) {
     address,
     name: f[1],
     deviceType: f[2],
+    userId: f[4] || "",
     uuid: f[6],
     canSync: f[8] === "1",
     anchorWatchTick: parseInt(f[F_ANCHOR_TICK], 10) || 0,
@@ -181,6 +187,10 @@ export class TimeZeroSync {
   constructor(app, options = {}) {
     this.app = app;
     this.hostName = options.hostName || "SignalK";
+    // My TIMEZERO user id, advertised in the beacon. When set (and matching the
+    // TimeZero instances'), TimeZero syncs with us on any network; when empty,
+    // sync is limited to the NavNet subnet. See onNavNet/canReachPeers.
+    this.userId = (options.userId || "").trim();
     this.uuid = makeUuid();
     this.socket = null;
     this.server = null;
@@ -196,7 +206,29 @@ export class TimeZeroSync {
     // Called when a TZ peer pushes an anchor to us: (anchor|null) => void.
     // anchor is {position, radius} to set, or null to raise.
     this.onRemoteAnchor = options.onRemoteAnchor || (() => {});
+    // Peers discovered via the beacon, keyed by source IP, used to decide who
+    // may talk to the sync endpoint when authorising by user id.
+    this.peers = new Map();
     this.started = false;
+  }
+
+  // Whether an address may use the sync endpoint.
+  //
+  // NavNet peers are always allowed: that is the subnet TimeZero itself trusts
+  // for account-free sync, and it's a dedicated instrument network.
+  //
+  // Off NavNet, an address is allowed only once we've seen it broadcast a
+  // beacon carrying our configured user id. That keeps the safety-critical
+  // endpoint closed to arbitrary LAN hosts — matching TimeZero's own rule,
+  // which pairs peers on user id rather than opening up to the whole network.
+  isTrustedPeer(address) {
+    if (!address)
+      return false;
+    if (address.startsWith("172.31."))
+      return true;
+    if (!this.userId)
+      return false;
+    return this.peers.get(address)?.userId === this.userId;
   }
 
   // True only when Signal K has a 172.31.x.x address — TZ's account-free LAN
@@ -266,14 +298,12 @@ export class TimeZeroSync {
   _startServer() {
     const server = http.createServer((req, res) => {
       try {
-        // Trust only NavNet (172.31.x.x) clients. TimeZero's anchor watch is
-        // safety-critical and the endpoint is unauthenticated plaintext HTTP
-        // (the protocol offers no auth), so source-IP is the access control:
-        // a GET discloses the boat's position and a POST can raise or move the
-        // anchor. Anything off NavNet is refused — matching the subnet TZ
-        // itself restricts account-free sync to (see _navNetBroadcasts).
+        // The endpoint is unauthenticated plaintext HTTP (the protocol offers
+        // no auth) and the anchor watch is safety-critical — a GET discloses
+        // the boat's position and a POST can move or raise the anchor — so
+        // every request is checked against the peers we trust.
         const remote = (req.socket.remoteAddress || "").replace(/^::ffff:/, "");
-        if (!remote.startsWith("172.31.")) {
+        if (!this.isTrustedPeer(remote)) {
           res.writeHead(403);
           res.end();
           return;
@@ -349,6 +379,22 @@ export class TimeZeroSync {
     socket.on("error", (err) => {
       this.app.error(`TimeZero sync discovery error: ${err.message}`);
     });
+    socket.on("message", (msg, rinfo) => {
+      try {
+        const peer = parseBeacon(msg.toString("utf8"), rinfo.address);
+        // Ignore our own beacon echoing back off the broadcast.
+        if (!peer || peer.uuid?.endsWith(this.uuid))
+          return;
+        const known = this.peers.get(rinfo.address);
+        this.peers.set(rinfo.address, peer);
+        if (!known)
+          this.app.debug(
+            `TimeZero peer ${peer.name} (${rinfo.address}) ${peer.deviceType}`,
+          );
+      } catch {
+        /* not a beacon we understand */
+      }
+    });
     socket.bind(DISCOVERY_PORT, () => {
       try {
         socket.setBroadcast(true);
@@ -371,6 +417,7 @@ export class TimeZeroSync {
       buildBeacon({
         hostName: this.hostName,
         uuid: this.uuid,
+        userId: this.userId,
         anchorWatchTick: this.anchorTick,
         currentTick: this.anchorTick,
         // High so we win TZ's master election and it pulls from us.
@@ -386,19 +433,27 @@ export class TimeZeroSync {
     }
   }
 
-  // Broadcast only onto NavNet (172.31.x.x): TZ's account-free trust check
-  // accepts a peer only if its source IP is in that subnet, so sending from
-  // any other interface would just be discovered-but-rejected.
+  // Where to send the beacon.
+  //
+  // Without a user id, TimeZero's account-free trust check accepts a peer only
+  // if its source IP is in 172.31.x.x, so broadcasting anywhere else would just
+  // be discovered-and-rejected — restrict to NavNet.
+  //
+  // With a user id, TimeZero matches on the id instead of the subnet, so we
+  // broadcast on every interface to reach peers on ordinary LANs.
   _navNetBroadcasts() {
     const out = new Set();
+    const navNetOnly = !this.userId;
     try {
       for (const list of Object.values(os.networkInterfaces())) {
         for (const ni of list) {
-          if (ni.family === "IPv4" && ni.address.startsWith("172.31.")) {
-            const ip = ni.address.split(".").map(Number);
-            const mask = ni.netmask.split(".").map(Number);
-            out.add(ip.map((o, i) => (o & mask[i]) | (~mask[i] & 255)).join("."));
-          }
+          if (ni.family !== "IPv4" || ni.internal)
+            continue;
+          if (navNetOnly && !ni.address.startsWith("172.31."))
+            continue;
+          const ip = ni.address.split(".").map(Number);
+          const mask = ni.netmask.split(".").map(Number);
+          out.add(ip.map((o, i) => (o & mask[i]) | (~mask[i] & 255)).join("."));
         }
       }
     } catch {

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -168,6 +168,61 @@ describe("discovery beacon", () => {
   });
 });
 
+describe("My TIMEZERO user id pairing", () => {
+  test("advertises the user id in beacon field 4", () => {
+    const f = buildBeacon({
+      hostName: "SK",
+      uuid: "u",
+      userId: "user-123",
+    }).split(";");
+    assert.equal(f[4], "user-123");
+  });
+
+  test("leaves field 4 empty when no user id is configured", () => {
+    const f = buildBeacon({ hostName: "SK", uuid: "u" }).split(";");
+    assert.equal(f[4], "");
+  });
+
+  test("parses a peer's user id out of its beacon", () => {
+    const raw =
+      "TZ Sync 1.0;NAV;TZ Professional;;user-123;;NAV/uuid;34944412;1;1;10;1;0;5;2;0;0";
+    assert.equal(parseBeacon(raw, "192.168.0.9").userId, "user-123");
+  });
+
+  describe("isTrustedPeer", () => {
+    const seenPeer = (sync, address, userId) =>
+      sync.peers.set(address, { address, userId });
+
+    test("always trusts NavNet addresses", () => {
+      const sync = new TimeZeroSync(stubApp(), {});
+      assert.equal(sync.isTrustedPeer("172.31.3.54"), true);
+    });
+
+    test("rejects off-NavNet addresses when no user id is configured", () => {
+      const sync = new TimeZeroSync(stubApp(), {});
+      assert.equal(sync.isTrustedPeer("192.168.0.9"), false);
+    });
+
+    test("trusts an off-NavNet peer that advertised our user id", () => {
+      const sync = new TimeZeroSync(stubApp(), { userId: "user-123" });
+      seenPeer(sync, "192.168.0.9", "user-123");
+      assert.equal(sync.isTrustedPeer("192.168.0.9"), true);
+    });
+
+    test("rejects an off-NavNet peer advertising a different user id", () => {
+      const sync = new TimeZeroSync(stubApp(), { userId: "user-123" });
+      seenPeer(sync, "192.168.0.9", "someone-else");
+      assert.equal(sync.isTrustedPeer("192.168.0.9"), false);
+    });
+
+    test("rejects an unknown address even with a user id configured", () => {
+      const sync = new TimeZeroSync(stubApp(), { userId: "user-123" });
+      assert.equal(sync.isTrustedPeer("192.168.0.99"), false);
+      assert.equal(sync.isTrustedPeer(""), false);
+    });
+  });
+});
+
 describe("remote anchor apply (higher-tick-wins)", () => {
   const remoteBody = (tick, values = "NULL,10,0,0") =>
     JSON.stringify({ ChangeTick: tick, Values: values });


### PR DESCRIPTION
Follow-up to #30, addressing @seabits-steve's question there: the merged version only syncs inside a Furuno NavNet (`172.31.x.x`), which rules out anyone running TimeZero on an ordinary LAN.

## What

TimeZero decides whether to trust a sync peer in one of two ways:

1. **Subnet** — it syncs freely inside a NavNet. This is what #30 shipped and what I can verify against my own hardware.
2. **Matching My TIMEZERO user ID** — it also pairs peers advertising the same user ID, on any network. That path wasn't supported.

This adds a **timeZeroUserId** option that advertises the ID in our discovery beacon, so Signal K can pair with TimeZero on an ordinary LAN. Sync now starts when either a NavNet interface or a user ID is present; leaving the option blank keeps the previous behaviour exactly.

The user ID is a GUID that TimeZero broadcasts in cleartext in its own beacon (UDP 33000, field 5) and compares by plain string equality — there is no token exchange or server-side validation involved. It is only populated once TimeZero is signed in to a My TIMEZERO account.

## ⚠️ Experimental

**This path is not yet confirmed against a signed-in TimeZero.** Both of my TimeZero instances run inside the NavNet and neither is signed in to an account, so their beacons advertise an empty user ID — which means no value I set on my side can ever match, on any subnet. I verified that on the wire rather than assuming it.

The implementation follows directly from TimeZero's own pairing check, but that is not the same as seeing it work, so the option is labelled experimental in both the config UI and the README. @seabits-steve has offered to try it; I'm happy to fix up whatever he finds in a follow-up.

## Security

Enabling this deliberately does **not** open the sync endpoint to the whole LAN. The endpoint is unauthenticated plaintext HTTP (TimeZero's protocol offers nothing else) and the anchor watch is safety-critical — a GET discloses the boat position and a POST can move or raise the anchor. Access therefore mirrors TimeZero's own pairing rule: NavNet addresses stay trusted, and off NavNet a host may use the endpoint only once it has been seen broadcasting the configured user ID. Arbitrary hosts on the network still cannot read the position or touch the anchor.

## Tested

- 8 new unit tests covering user-ID beacon build/parse and the peer-trust rules (NavNet always trusted; off-NavNet trusted only on a matching advertised ID; unknown or mismatched hosts rejected).
- Full suite green (288 tests), lint and prettier clean.
- Verified our beacon round-trips a GUID user ID without a field-delimiter clash.
- The NavNet path from #30 is unaffected and still verified end to end against live TimeZero Professional hardware.
- The user-ID path itself is **not** verified — see above.