### PR TITLE
fix: read the TimeZero anchor tick from the right beacon field and pull from peers

### DIFF
--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -118,14 +118,20 @@ export function parseValues(values) {
   }
 }
 
-// Beacon field layout, verified against a live TZ beacon (semicolon-separated):
-//   TZ Sync 1.0;MASTERCABIN;TZ Professional;;;;MASTERCABIN/uuid;34944412;1;1;31859;1;0;158;1601;0;22347062
-//    [0]protocol [1]name [2]deviceType [3]layersToken [4..5]reserved
-//    [6]name/uuid [7]uniqueId [8]canSync [9]canCloudSync [10]currentTick
-//    [11]routeTick [12]fishItTick [13]anchorWatchTick [14]visibleHosts
-//    [15]reserved [16]largeDataHash
-const F_ANCHOR_TICK = 13;
-const F_VISIBLE_HOSTS = 14;
+// Beacon field layout, taken from live TimeZero beacons (semicolon-separated).
+// A signed-in TZ Professional looks like:
+//   TZ Sync 1.0;TZPRO-NAVPC;TZ Professional;;<userId>;Cloud;TZPRO-NAVPC/<uuid>;35847804;4;1;205253;95;1007586792;22;3151;0;270720187
+//    [0]protocol [1]name [2]deviceType [3]layersToken [4]userId [5]"Cloud" when
+//    cloud-connected [6]name/uuid [7]uniqueId [8]visibleHosts [9]canCloudSync
+//    [10]currentTick [11]activeRouteTick [12]largeDataHash [13]schemaVersion
+//    [14]anchorWatchTick [15]reserved [16]hash
+//
+// [14] is the anchor tick: it tracks the ChangeTick returned by
+// /LanSynchronizationApi/AnchorWatch and increments on every anchor edit, while
+// [13] stays put (it's the schema version — 22 on TZ, and the same across
+// unrelated peers). [11] likewise matches the ActiveRoute CurrentTick.
+const F_VISIBLE_HOSTS = 8;
+const F_ANCHOR_TICK = 14;
 
 export function buildBeacon(state) {
   return [
@@ -137,20 +143,21 @@ export function buildBeacon(state) {
     // same non-empty user id (plain string equality), which is what makes sync
     // work off the NavNet subnet. Empty falls back to the NavNet-only path.
     state.userId || "",
-    "", // [5] cloud token
+    "", // [5] "Cloud" when cloud-connected; we never are
     `${state.hostName}/${state.uuid}`,
-    "10000000",
-    "1", // [8] CanSync
+    "10000000", // [7] uniqueId
+    // [8] visibleHosts — how many peers we can see. TimeZero elects the host
+    // with the highest count as master, so advertise a high number to be
+    // chosen and have our anchor pulled.
+    String(state.visibleHosts ?? 1),
     "0", // [9] CanCloudSync
     String(state.currentTick ?? 1), // [10]
-    "1", // [11] routeTick
-    "0", // [12] fishItTick
-    String(state.anchorWatchTick ?? 0), // [13]
-    // [14] visibleHosts — claim a high count so TZ elects us master and pulls
-    // our anchor (master = max visible hosts). Harmless when we're not pushing.
-    String(state.visibleHosts ?? 1),
+    "1", // [11] activeRouteTick
+    "0", // [12] largeDataHash
+    "22", // [13] schemaVersion — TimeZero broadcasts 22
+    String(state.anchorWatchTick ?? 0), // [14]
     "0", // [15]
-    "0", // [16] largeDataHash
+    "0", // [16] hash
   ].join(";");
 }
 
@@ -159,7 +166,7 @@ export function parseBeacon(str, address) {
   if (typeof str !== "string" || !str.startsWith(PROTOCOL.split(" ")[0]))
     return null;
   const f = str.split(";");
-  if (f.length <= F_VISIBLE_HOSTS)
+  if (f.length <= F_ANCHOR_TICK)
     return null;
   return {
     address,
@@ -167,9 +174,11 @@ export function parseBeacon(str, address) {
     deviceType: f[2],
     userId: f[4] || "",
     uuid: f[6],
-    canSync: f[8] === "1",
-    anchorWatchTick: parseInt(f[F_ANCHOR_TICK], 10) || 0,
+    // TimeZero broadcasts a host count here rather than a flag, so treat any
+    // positive value as "can sync".
+    canSync: (parseInt(f[F_VISIBLE_HOSTS], 10) || 0) > 0,
     visibleHosts: parseInt(f[F_VISIBLE_HOSTS], 10) || 0,
+    anchorWatchTick: parseInt(f[F_ANCHOR_TICK], 10) || 0,
   };
 }
 
@@ -209,6 +218,10 @@ export class TimeZeroSync {
     // Peers discovered via the beacon, keyed by source IP, used to decide who
     // may talk to the sync endpoint when authorising by user id.
     this.peers = new Map();
+    // Guards against overlapping pulls; see _pullFrom.
+    this.pulling = false;
+    // NetworkID of the peer currently holding our sync lock, if any.
+    this.lockHolder = null;
     this.started = false;
   }
 
@@ -296,7 +309,20 @@ export class TimeZeroSync {
   }
 
   _startServer() {
-    const server = http.createServer((req, res) => {
+    const server = http.createServer((req, res) => this._handle(req, res));
+    server.on("error", (err) => {
+      this.app.error(`TimeZero sync HTTP server error: ${err.message}`);
+    });
+    server.listen(COMMAND_PORT, "0.0.0.0", () => {
+      this.app.debug(`TimeZero sync serving on :${COMMAND_PORT}`);
+    });
+    this.server = server;
+  }
+
+  // Handle one sync request. Split out from _startServer so the endpoint's
+  // behaviour can be exercised directly in tests.
+  _handle(req, res) {
+    {
       try {
         // The endpoint is unauthenticated plaintext HTTP (the protocol offers
         // no auth) and the anchor watch is safety-critical — a GET discloses
@@ -309,6 +335,30 @@ export class TimeZeroSync {
           return;
         }
         const path = (req.url || "").split("?")[0].replace(/\/+$/, "");
+
+        // Advisory sync lock, as TimeZero peers use between themselves: 202
+        // when granted, 409 while someone else holds it. Re-requesting your own
+        // lock is idempotent so a peer that missed our reply can retry.
+        if (path.endsWith("/LanSynchronizationApi/GetLock")) {
+          const who = new URL(req.url, "http://x").searchParams.get("NetworkID");
+          if (this.lockHolder && this.lockHolder !== who) {
+            res.writeHead(409);
+          } else {
+            this.lockHolder = who;
+            res.writeHead(202);
+          }
+          res.end();
+          return;
+        }
+        if (path.endsWith("/LanSynchronizationApi/ReleaseLock")) {
+          const who = new URL(req.url, "http://x").searchParams.get("NetworkID");
+          if (this.lockHolder === who)
+            this.lockHolder = null;
+          res.writeHead(200);
+          res.end();
+          return;
+        }
+
         const isAnchor = path.endsWith("/LanSynchronizationApi/AnchorWatch");
         if (isAnchor && req.method === "GET") {
           res.writeHead(200, { "Content-Type": "application/json" });
@@ -342,14 +392,70 @@ export class TimeZeroSync {
           /* response already gone */
         }
       }
+    }
+  }
+
+  // Fetch a peer's anchor after its beacon advertised a newer tick, following
+  // the same sequence TimeZero peers use between themselves: take the sync
+  // lock, GET the anchor, release the lock. The lock is advisory — TimeZero
+  // answers 202 when granted and 409 while another peer holds it — so a
+  // refusal just means "try again on the next beacon" rather than an error.
+  async _pullFrom(peer, previousTick) {
+    if (this.pulling)
+      return; // one pull at a time; the next beacon retries
+    this.pulling = true;
+    const networkId = `${this.hostName}/${this.uuid}`;
+    try {
+      const lock = await this._get(
+        peer.address,
+        `/LanSynchronizationApi/GetLock?NetworkID=${encodeURIComponent(networkId)}`,
+      );
+      if (lock.status !== 202) {
+        this.app.debug(
+          `TimeZero sync lock busy on ${peer.name} (${lock.status}); retrying next beacon`,
+        );
+        return;
+      }
+      try {
+        const res = await this._get(
+          peer.address,
+          "/LanSynchronizationApi/AnchorWatch",
+        );
+        if (res.status === 200) {
+          this.app.debug(
+            `TimeZero sync pulled anchor from ${peer.name} (tick ${previousTick ?? "?"} -> ${peer.anchorWatchTick})`,
+          );
+          this._applyRemote(res.body);
+        }
+      } finally {
+        await this._get(
+          peer.address,
+          `/LanSynchronizationApi/ReleaseLock?NetworkID=${encodeURIComponent(networkId)}`,
+        ).catch(() => {});
+      }
+    } catch (err) {
+      this.app.debug(`TimeZero sync pull from ${peer.name} failed: ${err.message}`);
+    } finally {
+      this.pulling = false;
+    }
+  }
+
+  // Minimal HTTP GET. TimeZero responds with chunked encoding, so this must
+  // speak HTTP/1.1 (Node's http client does).
+  _get(address, path) {
+    return new Promise((resolve, reject) => {
+      const req = http.get(
+        { host: address, port: COMMAND_PORT, path, timeout: 5000 },
+        (res) => {
+          let body = "";
+          res.setEncoding("utf8");
+          res.on("data", (c) => (body += c));
+          res.on("end", () => resolve({ status: res.statusCode, body }));
+        },
+      );
+      req.on("timeout", () => req.destroy(new Error("timeout")));
+      req.on("error", reject);
     });
-    server.on("error", (err) => {
-      this.app.error(`TimeZero sync HTTP server error: ${err.message}`);
-    });
-    server.listen(COMMAND_PORT, "0.0.0.0", () => {
-      this.app.debug(`TimeZero sync serving on :${COMMAND_PORT}`);
-    });
-    this.server = server;
   }
 
   _applyRemote(body) {
@@ -391,6 +497,10 @@ export class TimeZeroSync {
           this.app.debug(
             `TimeZero peer ${peer.name} (${rinfo.address}) ${peer.deviceType}`,
           );
+        // A peer advertising a higher anchor tick than ours has an anchor
+        // change we haven't seen — go and fetch it.
+        if (this.isTrustedPeer(rinfo.address) && peer.anchorWatchTick > this.anchorTick)
+          this._pullFrom(peer, known?.anchorWatchTick);
       } catch {
         /* not a beacon we understand */
       }

--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -32,6 +32,8 @@ import os from "os";
 const DISCOVERY_PORT = 33000;
 const COMMAND_PORT = 32000;
 const BEACON_INTERVAL_MS = 1000;
+// How long a peer may hold the sync lock before we treat it as abandoned.
+const LOCK_TIMEOUT_MS = 30000;
 const PROTOCOL = "TZ Sync 1.0";
 const DEVICE_TYPE = "TZ iBoat"; // a legitimate sync-peer device type
 
@@ -220,9 +222,18 @@ export class TimeZeroSync {
     this.peers = new Map();
     // Guards against overlapping pulls; see _pullFrom.
     this.pulling = false;
-    // NetworkID of the peer currently holding our sync lock, if any.
+    // NetworkID of the peer currently holding our sync lock, and when it was
+    // taken. A peer that dies mid-sync never sends ReleaseLock, so the lock
+    // expires rather than blocking every other peer until a plugin restart.
     this.lockHolder = null;
+    this.lockTakenAt = 0;
     this.started = false;
+  }
+
+  // A held lock older than LOCK_TIMEOUT_MS is treated as abandoned. Peers hold
+  // it only for the few requests of one sync round, so this is generous.
+  _lockExpired() {
+    return Date.now() - this.lockTakenAt > LOCK_TIMEOUT_MS;
   }
 
   // Whether an address may use the sync endpoint.
@@ -290,8 +301,25 @@ export class TimeZeroSync {
   }
 
   // Bump our advertised anchor tick so the next beacon tells peers we changed.
+  //
+  // The tick is account-wide in TimeZero and already in the thousands, so it
+  // isn't enough to increment our own counter: after a plugin restart we would
+  // start again from 1 and every local anchor change would look older than
+  // TimeZero's current state, so no peer would ever pull it. Step past the
+  // highest tick any peer has advertised instead, which keeps a local change
+  // strictly newer than everything we've seen.
   notifyAnchorChanged() {
-    this.anchorTick += 1;
+    this.anchorTick = Math.max(this.anchorTick, this._highestPeerTick()) + 1;
+  }
+
+  // The highest anchor tick advertised by any peer we've heard from.
+  _highestPeerTick() {
+    let highest = 0;
+    for (const peer of this.peers.values()) {
+      if (peer.anchorWatchTick > highest)
+        highest = peer.anchorWatchTick;
+    }
+    return highest;
   }
 
   _currentSerialized() {
@@ -322,75 +350,74 @@ export class TimeZeroSync {
   // Handle one sync request. Split out from _startServer so the endpoint's
   // behaviour can be exercised directly in tests.
   _handle(req, res) {
-    {
-      try {
-        // The endpoint is unauthenticated plaintext HTTP (the protocol offers
-        // no auth) and the anchor watch is safety-critical — a GET discloses
-        // the boat's position and a POST can move or raise the anchor — so
-        // every request is checked against the peers we trust.
-        const remote = (req.socket.remoteAddress || "").replace(/^::ffff:/, "");
-        if (!this.isTrustedPeer(remote)) {
-          res.writeHead(403);
-          res.end();
-          return;
-        }
-        const path = (req.url || "").split("?")[0].replace(/\/+$/, "");
+    try {
+      // The endpoint is unauthenticated plaintext HTTP (the protocol offers
+      // no auth) and the anchor watch is safety-critical — a GET discloses
+      // the boat's position and a POST can move or raise the anchor — so
+      // every request is checked against the peers we trust.
+      const remote = (req.socket.remoteAddress || "").replace(/^::ffff:/, "");
+      if (!this.isTrustedPeer(remote)) {
+        res.writeHead(403);
+        res.end();
+        return;
+      }
+      const path = (req.url || "").split("?")[0].replace(/\/+$/, "");
 
-        // Advisory sync lock, as TimeZero peers use between themselves: 202
-        // when granted, 409 while someone else holds it. Re-requesting your own
-        // lock is idempotent so a peer that missed our reply can retry.
-        if (path.endsWith("/LanSynchronizationApi/GetLock")) {
-          const who = new URL(req.url, "http://x").searchParams.get("NetworkID");
-          if (this.lockHolder && this.lockHolder !== who) {
-            res.writeHead(409);
-          } else {
-            this.lockHolder = who;
-            res.writeHead(202);
-          }
-          res.end();
-          return;
+      // Advisory sync lock, as TimeZero peers use between themselves: 202
+      // when granted, 409 while someone else holds it. Re-requesting your own
+      // lock is idempotent so a peer that missed our reply can retry.
+      if (path.endsWith("/LanSynchronizationApi/GetLock")) {
+        const who = new URL(req.url, "http://x").searchParams.get("NetworkID");
+        if (this.lockHolder && this.lockHolder !== who && !this._lockExpired()) {
+          res.writeHead(409);
+        } else {
+          this.lockHolder = who;
+          this.lockTakenAt = Date.now();
+          res.writeHead(202);
         }
-        if (path.endsWith("/LanSynchronizationApi/ReleaseLock")) {
-          const who = new URL(req.url, "http://x").searchParams.get("NetworkID");
-          if (this.lockHolder === who)
-            this.lockHolder = null;
-          res.writeHead(200);
-          res.end();
-          return;
-        }
+        res.end();
+        return;
+      }
+      if (path.endsWith("/LanSynchronizationApi/ReleaseLock")) {
+        const who = new URL(req.url, "http://x").searchParams.get("NetworkID");
+        if (this.lockHolder === who)
+          this.lockHolder = null;
+        res.writeHead(200);
+        res.end();
+        return;
+      }
 
-        const isAnchor = path.endsWith("/LanSynchronizationApi/AnchorWatch");
-        if (isAnchor && req.method === "GET") {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(this._currentSerialized()));
-          return;
-        }
-        if (isAnchor && req.method === "POST") {
-          let body = "";
-          req.on("data", (c) => {
-            body += c;
-            if (body.length > 1e6)
-              req.destroy(); // guard against a runaway upload
-          });
-          req.on("end", () => {
-            this._applyRemote(body);
-            res.writeHead(201);
-            res.end();
-          });
-          return;
-        }
-        // Answer 200 to TZ's reachability probe (bare GET /) and everything
-        // else so it treats us as a live peer.
+      const isAnchor = path.endsWith("/LanSynchronizationApi/AnchorWatch");
+      if (isAnchor && req.method === "GET") {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end("{}");
-      } catch (err) {
-        this.app.error(`TimeZero sync request error: ${err.message}`);
-        try {
-          res.writeHead(500);
+        res.end(JSON.stringify(this._currentSerialized()));
+        return;
+      }
+      if (isAnchor && req.method === "POST") {
+        let body = "";
+        req.on("data", (c) => {
+          body += c;
+          if (body.length > 1e6)
+            req.destroy(); // guard against a runaway upload
+        });
+        req.on("end", () => {
+          this._applyRemote(body);
+          res.writeHead(201);
           res.end();
-        } catch {
-          /* response already gone */
-        }
+        });
+        return;
+      }
+      // Answer 200 to TZ's reachability probe (bare GET /) and everything
+      // else so it treats us as a live peer.
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("{}");
+    } catch (err) {
+      this.app.error(`TimeZero sync request error: ${err.message}`);
+      try {
+        res.writeHead(500);
+        res.end();
+      } catch {
+        /* response already gone */
       }
     }
   }

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -133,9 +133,9 @@ describe("discovery beacon", () => {
     assert.equal(f[0], "TZ Sync 1.0");
     assert.equal(f[1], "SignalK");
     assert.equal(f[2], "TZ iBoat");
-    assert.equal(f[8], "1"); // CanSync
-    assert.equal(f[13], "7"); // anchorWatchTick
-    assert.equal(f[14], "99"); // visibleHosts (master election)
+    assert.equal(f[8], "99"); // visibleHosts (master election)
+    assert.equal(f[13], "22"); // schemaVersion, as TimeZero broadcasts
+    assert.equal(f[14], "7"); // anchorWatchTick
   });
 
   test("round-trips a beacon it built", () => {
@@ -152,14 +152,28 @@ describe("discovery beacon", () => {
     assert.equal(peer.address, "172.31.3.9");
   });
 
-  test("parses a real MASTERCABIN beacon", () => {
+  // A real beacon from a signed-in TZ Professional. The anchor tick lives in
+  // field 14 (3151, matching the ChangeTick its AnchorWatch endpoint returned);
+  // field 13 is the schema version and stays at 22 across anchor edits.
+  test("parses a real signed-in TZ Professional beacon", () => {
     const raw =
-      "TZ Sync 1.0;MASTERCABIN;TZ Professional;;;;MASTERCABIN/d5ff170c;34944412;1;1;31859;1;0;158;1601;0;22347062";
-    const peer = parseBeacon(raw, "172.31.3.54");
-    assert.equal(peer.name, "MASTERCABIN");
+      "TZ Sync 1.0;TZPRO-NAVPC;TZ Professional;;user-guid;Cloud;TZPRO-NAVPC/5425c908;35847804;4;1;205253;95;1007586792;22;3151;0;270720187";
+    const peer = parseBeacon(raw, "192.168.1.108");
+    assert.equal(peer.name, "TZPRO-NAVPC");
     assert.equal(peer.deviceType, "TZ Professional");
+    assert.equal(peer.userId, "user-guid");
     assert.equal(peer.canSync, true);
-    assert.equal(peer.anchorWatchTick, 158);
+    assert.equal(peer.visibleHosts, 4);
+    assert.equal(peer.anchorWatchTick, 3151);
+  });
+
+  // The anchor tick is what moves when the operator edits the anchor: across
+  // six edits field 14 stepped 3143..3148 while field 13 stayed at 22.
+  test("tracks the anchor tick across an edit, ignoring the static field 13", () => {
+    const at = (tick) =>
+      `TZ Sync 1.0;TZPRO-NAVPC;TZ Professional;;u;Cloud;TZPRO-NAVPC/x;35847804;4;1;205253;95;1007586792;22;${tick};0;0`;
+    assert.equal(parseBeacon(at(3143), "1.2.3.4").anchorWatchTick, 3143);
+    assert.equal(parseBeacon(at(3148), "1.2.3.4").anchorWatchTick, 3148);
   });
 
   test("ignores non-TimeZero UDP payloads", () => {
@@ -220,6 +234,125 @@ describe("My TIMEZERO user id pairing", () => {
       assert.equal(sync.isTrustedPeer("192.168.0.99"), false);
       assert.equal(sync.isTrustedPeer(""), false);
     });
+  });
+});
+
+describe("pulling from a peer that advertises a newer anchor", () => {
+  // Stand up a stub that answers like TimeZero does, so the pull can be
+  // exercised end to end: lock, fetch, release.
+  const startPeer = async (anchorValues) => {
+    const { createServer } = await import("node:http");
+    const seen = [];
+    const server = createServer((req, res) => {
+      seen.push(req.url.split("?")[0]);
+      if (req.url.includes("GetLock")) {
+        res.writeHead(202);
+        res.end();
+      } else if (req.url.includes("ReleaseLock")) {
+        res.writeHead(200);
+        res.end();
+      } else {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ChangeTick: 3152, Values: anchorValues }));
+      }
+    });
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    return { server, seen, port: server.address().port };
+  };
+
+  test("locks, fetches the anchor, then releases", async () => {
+    const peer = await startPeer("X'0400000000000000000000C350',10,0,0");
+    try {
+      let applied;
+      const sync = new TimeZeroSync(stubApp(), {
+        onRemoteAnchor: (a) => {
+          applied = a;
+        },
+      });
+      // Point the pull at the stub's port rather than TimeZero's fixed one.
+      sync._get = (address, path) =>
+        new Promise((resolve, reject) => {
+          import("node:http").then(({ get }) => {
+            const req = get(
+              { host: "127.0.0.1", port: peer.port, path },
+              (res) => {
+                let body = "";
+                res.on("data", (c) => (body += c));
+                res.on("end", () => resolve({ status: res.statusCode, body }));
+              },
+            );
+            req.on("error", reject);
+          });
+        });
+      sync.anchorTick = 1;
+      await sync._pullFrom(
+        { address: "127.0.0.1", name: "TZPRO", anchorWatchTick: 3152 },
+        1,
+      );
+      assert.deepEqual(peer.seen, [
+        "/LanSynchronizationApi/GetLock",
+        "/LanSynchronizationApi/AnchorWatch",
+        "/LanSynchronizationApi/ReleaseLock",
+      ]);
+      assert.ok(applied, "anchor should have been applied");
+      assert.equal(applied.radius, 500);
+      assert.equal(sync.anchorTick, 3152);
+    } finally {
+      peer.server.close();
+    }
+  });
+
+  test("gives up quietly when the peer's lock is held", async () => {
+    const sync = new TimeZeroSync(stubApp(), {
+      onRemoteAnchor: () => assert.fail("must not apply without the lock"),
+    });
+    sync._get = async (_a, path) =>
+      path.includes("GetLock")
+        ? { status: 409, body: "" }
+        : { status: 200, body: "{}" };
+    sync.anchorTick = 1;
+    await sync._pullFrom({ address: "1.2.3.4", name: "TZ", anchorWatchTick: 9 }, 1);
+    assert.equal(sync.anchorTick, 1); // unchanged
+  });
+});
+
+describe("sync lock endpoint", () => {
+  // Drive the real request handler over a loopback socket, so the lock
+  // behaviour a TimeZero peer would see is what's actually tested.
+  const callServed = async (sync, url) => {
+    const { createServer, get } = await import("node:http");
+    const server = createServer((req, res) => {
+      // Force the trust check to pass for loopback in this test.
+      Object.defineProperty(req.socket, "remoteAddress", {
+        value: "172.31.0.9",
+        configurable: true,
+      });
+      sync._handle(req, res);
+    });
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    const port = server.address().port;
+    const status = await new Promise((resolve, reject) => {
+      const req = get({ host: "127.0.0.1", port, path: url }, (res) => {
+        res.resume();
+        res.on("end", () => resolve(res.statusCode));
+      });
+      req.on("error", reject);
+    });
+    server.close();
+    return status;
+  };
+
+  test("grants the lock, refuses a second holder, and frees it on release", async () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    const lock = "/LanSynchronizationApi/GetLock?NetworkID=";
+    assert.equal(await callServed(sync, `${lock}peerA`), 202);
+    assert.equal(await callServed(sync, `${lock}peerB`), 409, "peerB is blocked");
+    assert.equal(await callServed(sync, `${lock}peerA`), 202, "peerA is idempotent");
+    assert.equal(
+      await callServed(sync, "/LanSynchronizationApi/ReleaseLock?NetworkID=peerA"),
+      200,
+    );
+    assert.equal(await callServed(sync, `${lock}peerB`), 202, "freed for peerB");
   });
 });
 

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -354,6 +354,62 @@ describe("sync lock endpoint", () => {
     );
     assert.equal(await callServed(sync, `${lock}peerB`), 202, "freed for peerB");
   });
+
+  test("hands the lock to another peer once the holder's has expired", async () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    const lock = "/LanSynchronizationApi/GetLock?NetworkID=";
+    assert.equal(await callServed(sync, `${lock}peerA`), 202);
+    assert.equal(await callServed(sync, `${lock}peerB`), 409);
+    // peerA vanished without releasing.
+    sync.lockTakenAt = Date.now() - 31000;
+    assert.equal(await callServed(sync, `${lock}peerB`), 202);
+  });
+});
+
+describe("advertised anchor tick", () => {
+  // TimeZero's tick is account-wide and already in the thousands, so a local
+  // change has to step past whatever the peers are advertising. Counting up
+  // from our own starting value would leave us permanently "older" than
+  // TimeZero and nothing would ever pull from us.
+  test("steps past the highest tick any peer advertises", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    sync.peers.set("192.168.1.108", { anchorWatchTick: 3151 });
+    sync.peers.set("192.168.1.175", { anchorWatchTick: 3150 });
+    sync.notifyAnchorChanged();
+    assert.equal(sync.anchorTick, 3152);
+  });
+
+  test("survives a restart: a local change still outranks TimeZero", () => {
+    // Fresh instance — anchorTick is back to its initial value.
+    const sync = new TimeZeroSync(stubApp(), {});
+    assert.ok(sync.anchorTick < 3151, "starts below TimeZero's tick");
+    sync.peers.set("192.168.1.108", { anchorWatchTick: 3151 });
+    sync.notifyAnchorChanged();
+    assert.ok(
+      sync.anchorTick > 3151,
+      "a local anchor change must look newer than TimeZero's state",
+    );
+  });
+
+  test("still advances when no peers are known", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    const before = sync.anchorTick;
+    sync.notifyAnchorChanged();
+    assert.equal(sync.anchorTick, before + 1);
+  });
+});
+
+describe("sync lock expiry", () => {
+  test("a lock held by a vanished peer is reclaimed", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    sync.lockHolder = "peerThatDied";
+    sync.lockTakenAt = Date.now();
+    assert.equal(sync._lockExpired(), false, "a fresh lock is honoured");
+    // The peer never sent ReleaseLock; without expiry every other peer would
+    // get 409 until the plugin restarted.
+    sync.lockTakenAt = Date.now() - 31000;
+    assert.equal(sync._lockExpired(), true);
+  });
 });
 
 describe("remote anchor apply (higher-tick-wins)", () => {


### PR DESCRIPTION
Fixes both problems @seabits-steve reported in #32, using the packet captures he provided from a signed-in TimeZero.

## The anchor tick is beacon field 14, not 13

Field 13 is the schema version — a constant `22` across all his peers — so the tick was being read from a field that never moves, and our own tick was written into a field TimeZero doesn't read. A TimeZero anchor edit was therefore invisible to us.

His capture settles it two ways beyond the six anchor edits he observed:

- NAVPC's field 14 is `3151`, and its `/LanSynchronizationApi/AnchorWatch` returns `{"ChangeTick":3151,...}`
- its field 11 is `95`, and its `/LanSynchronizationApi/ActiveRoute` returns `"CurrentTick":95`

Field 8 is also corrected: TimeZero sends a host count there (`4`), not a boolean, so it is parsed as a number and any positive value counts as sync-capable.

The mapping originally came from a TimeZero that was not signed in, where field 13 held `158` and the AnchorWatch ChangeTick happened to be `158` as well — a coincidence in a single static sample.

## Nothing ever pulled from a peer

`notifyTimeZero()` only incremented a counter and waited for TimeZero to come and ask, which covers Signal K → TimeZero but not the reverse, so an anchor set in TimeZero never reached Signal K. There was no outbound HTTP in the module at all.

Signal K now watches each peer's beacon and, when one advertises a newer anchor tick, fetches it the way TimeZero peers do between themselves:

```
GetLock?NetworkID=<host>/<uuid>   → 202 (409 = held by another peer, retry next beacon)
AnchorWatch                        → apply
ReleaseLock?NetworkID=<host>/<uuid>
```

The lock endpoints are served as well, since peers take our lock before reading from us. It is advisory: 202 when granted, 409 while another peer holds it, idempotent for the same holder, and a refusal simply retries on the next beacon rather than erroring.

## Tested

- Real beacons from #32 are now test fixtures, including a signed-in TZ Professional beacon and a tick-advancing pair, so this mapping cannot silently regress.
- New tests drive the pull end to end against a stub peer (asserting the exact GetLock → AnchorWatch → ReleaseLock order), cover a 409-held lock, and exercise the served lock endpoints over a real socket.
- Full suite green (292 tests), lint and prettier clean.

Not verified from my side: I have no signed-in TimeZero, so I cannot confirm that a TimeZero anchor edit now lands in Signal K, nor that TimeZero accepts our beacon with the corrected field values. @seabits-steve has offered to test.