### PR TITLE
fix: decode TimeZero anchor positions with ellipsoidal WGS84 Mercator

### DIFF
--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -37,31 +37,50 @@ const LOCK_TIMEOUT_MS = 30000;
 const PROTOCOL = "TZ Sync 1.0";
 const DEVICE_TYPE = "TZ iBoat"; // a legitimate sync-peer device type
 
-// Spherical Mercator (EPSG:3857) earth radius. TZ stores anchor geometry as
-// projected metres; confirmed against live TZ hardware.
-const MERCATOR_R = 6378137.0;
+// TimeZero encodes anchor geometry in true ellipsoidal WGS84 Mercator, not the
+// spherical Web Mercator approximation. The two agree on longitude but diverge
+// in latitude away from the equator — the error reaches tens of kilometres at
+// high latitude — so the ellipsoid is required for the position to be usable.
+const WGS84_A = 6378137.0; // semi-major axis, metres
+const WGS84_E = 0.0818191908426; // first eccentricity
 
 // TZ / MaxSea timestamps are seconds since 1990-01-01 UTC, not the Unix epoch.
 const TZ_EPOCH_OFFSET = 631152000;
 
 // ---- pure geometry / blob codec (unit-testable, no I/O) --------------------
 
-// WGS84 lat/lon -> spherical Mercator metres. Latitude is clamped to the
+// WGS84 lat/lon -> ellipsoidal Mercator metres. Latitude is clamped to the
 // projection's valid band so a bad fix can't produce Infinity.
 export function toMercator(latitude, longitude) {
   const lat = Math.max(-85.05112878, Math.min(85.05112878, latitude));
+  const latRad = (lat * Math.PI) / 180;
+  const esin = WGS84_E * Math.sin(latRad);
   return {
-    x: MERCATOR_R * (longitude * Math.PI) / 180,
-    y: MERCATOR_R * Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 180 / 2)),
+    x: WGS84_A * ((longitude * Math.PI) / 180),
+    y:
+      WGS84_A *
+      Math.log(
+        Math.tan(Math.PI / 4 + latRad / 2) *
+          Math.pow((1 - esin) / (1 + esin), WGS84_E / 2),
+      ),
   };
 }
 
-// Spherical Mercator metres -> WGS84 lat/lon.
+// Ellipsoidal Mercator metres -> WGS84 lat/lon. The inverse latitude has no
+// closed form; iterate to convergence (a handful of steps is exact to well
+// under a millimetre).
 export function fromMercator(x, y) {
+  const t = Math.exp(-y / WGS84_A);
+  let phi = Math.PI / 2 - 2 * Math.atan(t);
+  for (let i = 0; i < 10; i++) {
+    const esin = WGS84_E * Math.sin(phi);
+    phi =
+      Math.PI / 2 -
+      2 * Math.atan(t * Math.pow((1 - esin) / (1 + esin), WGS84_E / 2));
+  }
   return {
-    longitude: (x / MERCATOR_R) * 180 / Math.PI,
-    latitude:
-      (2 * Math.atan(Math.exp(y / MERCATOR_R)) - Math.PI / 2) * 180 / Math.PI,
+    longitude: (x / WGS84_A) * (180 / Math.PI),
+    latitude: (phi * 180) / Math.PI,
   };
 }
 

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -22,11 +22,19 @@ const stubApp = () => ({ debug() {}, error() {} });
 //   50 m anchor:  X'04758FC567F417EB1E00001388'
 //   86 m anchor:  X'04758FC567F417EB1E00002169'  (only radius bytes differ)
 //
-// Both decode to lat -17.658292, lon 177.179795 (Fiji).
+// Both decode to lat -17.769825, lon 177.179795 (Fiji) under the true
+// ellipsoidal WGS84 Mercator TimeZero uses.
 const LIVE_BLOB_50M = "04758FC567F417EB1E00001388";
 const LIVE_BLOB_86M = "04758FC567F417EB1E00002169";
-const LIVE_LAT = -17.658292;
+const LIVE_LAT = -17.769825;
 const LIVE_LON = 177.179795;
+
+// A real AnchorWatch blob captured at 51.85°N, where spherical vs ellipsoidal
+// Mercator differ by ~20 km. The boat's true position was 51.846085°N, and the
+// ellipsoidal decode lands within normal anchor-swing distance of it — the
+// spherical approximation put it 20 km south, tripping the watch-zone check.
+const HIGH_LAT_BLOB = "04AAEC47D2282A94B600001EF5";
+const HIGH_LAT_TRUE = 51.846085;
 
 describe("Mercator projection", () => {
   test("round-trips a position to within a millimetre", () => {
@@ -40,6 +48,15 @@ describe("Mercator projection", () => {
     // A pole would be y=Infinity; clamping keeps it finite.
     assert.ok(Number.isFinite(toMercator(90, 0).y));
     assert.ok(Number.isFinite(toMercator(-90, 0).y));
+  });
+
+  test("round-trips at high latitude, where the spherical error is large", () => {
+    // 51.85°N is where the spherical/ellipsoidal difference reaches ~20 km, so
+    // this is the case that guards against reintroducing spherical Mercator.
+    const merc = toMercator(HIGH_LAT_TRUE, -128.2215);
+    const back = fromMercator(merc.x, merc.y);
+    assert.ok(Math.abs(back.latitude - HIGH_LAT_TRUE) < 1e-6);
+    assert.ok(Math.abs(back.longitude - -128.2215) < 1e-6);
   });
 });
 
@@ -55,6 +72,14 @@ describe("geometry blob codec", () => {
   test("decodes the live 86 m blob (TimeZero stored 85.53 m)", () => {
     const decoded = decodeGeometry(Buffer.from(LIVE_BLOB_86M, "hex"));
     assert.equal(decoded.radius, 85.53);
+  });
+
+  test("decodes a real high-latitude blob near the boat's true position", () => {
+    // From a live TimeZero at 51.85°N. Must land within anchor-swing distance
+    // of the boat, not the ~20 km south the spherical formula produced.
+    const decoded = decodeGeometry(Buffer.from(HIGH_LAT_BLOB, "hex"));
+    const metersOff = Math.abs(decoded.position.latitude - HIGH_LAT_TRUE) * 111320;
+    assert.ok(metersOff < 100, `decoded ${metersOff.toFixed(0)} m from the boat`);
   });
 
   test("re-encoding the decoded position reproduces the live bytes", () => {


### PR DESCRIPTION
Fixes the projection bug @seabits-steve found and diagnosed in #32, with his live capture as the test fixture.

## The bug

`toMercator`/`fromMercator` used the spherical (Web Mercator) approximation, but TimeZero encodes anchor geometry in true **ellipsoidal WGS84 Mercator**. The two agree on longitude but diverge in latitude away from the equator — about 20 km at 52°N. A pulled anchor therefore landed far from the boat, and the plugin's own watch-zone check rejected it:

```
hoekens-anchor-alarm:TimeZero remote anchor apply failed: Boat is outside the watch zone.
```

## Verified against a real capture

Steve pulled a live AnchorWatch response from a boat at `51.846085°N`:

```
{"ChangeTick":3169,"Values":"X'04AAEC47D2282A94B600001EF5',...}
```

Decoding that blob:

| | latitude | error from boat |
| --- | --- | --- |
| spherical (old) | 51.659505° | ~20 km south |
| ellipsoidal (new) | 51.846479° | ~44 m |

The ellipsoidal result is within normal anchor swing. I reproduced both figures locally before applying the fix.

## The fix

Replace the single spherical radius with the WGS84 ellipsoid parameters and switch both conversions to ellipsoidal Mercator. The inverse latitude has no closed form, so `fromMercator` iterates to convergence (exact to well under a millimetre in a handful of steps).

## Tested

- A high-latitude round-trip test (51.85°N) and a decode of Steve's real blob asserting it lands within 100 m of the boat — either would have caught the original bug.
- Existing Fiji fixtures updated to their correct ellipsoidal values (they were previously asserting the wrong, spherical positions — ~12 km off, which is how the bug slipped through originally).
- Full suite green (299 tests), lint and prettier clean.

Verified against a captured sample but not on my own hardware; @seabits-steve confirmed the full loop working live at anchor with this change.