### PR TITLE
fix(timezero): defer TZ master election when a real TZ peer is present

### DIFF
--- a/src/timezero-sync.js
+++ b/src/timezero-sync.js
@@ -32,8 +32,18 @@ import os from "os";
 const DISCOVERY_PORT = 33000;
 const COMMAND_PORT = 32000;
 const BEACON_INTERVAL_MS = 1000;
+// A peer whose last beacon is older than this is treated as gone. Beacons come
+// every second, so a few missed ones is a generous "no longer on the network".
+const PEER_STALE_MS = 5000;
 // How long a peer may hold the sync lock before we treat it as abandoned.
 const LOCK_TIMEOUT_MS = 30000;
+// visibleHosts we advertise when no other TZ peer is on the network: high so TZ
+// elects us master and pulls the anchor from us (its only path to a plugin-side
+// raise/drop). When real TZ peers are present we advertise LOW instead, so we
+// don't hijack the master election they run among themselves to sync
+// routes/marks — our own pull path doesn't depend on this field. See issue #36.
+const VISIBLE_HOSTS_SOLE = 99;
+const VISIBLE_HOSTS_DEFERRED = 1;
 const PROTOCOL = "TZ Sync 1.0";
 const DEVICE_TYPE = "TZ iBoat"; // a legitimate sync-peer device type
 
@@ -331,6 +341,34 @@ export class TimeZeroSync {
     this.anchorTick = Math.max(this.anchorTick, this._highestPeerTick()) + 1;
   }
 
+  // The visibleHosts count to advertise in our beacon.
+  //
+  // TZ elects the peer advertising the highest count as sync master and pulls
+  // from it, so a high value is how a plugin-side anchor raise/drop reaches TZ
+  // (the plugin never pushes to TZ; TZ has to pull). But when two real TZ
+  // instances are on the network they run that same election between themselves
+  // to sync routes/marks — a flat high value from us wins it and stalls their
+  // sync (issue #36). So advertise high only when we're the sole TZ authority,
+  // and step aside otherwise. Our own TZ->plugin pull is gated on the anchor
+  // tick and isTrustedPeer, not on this field, so it keeps working either way.
+  _advertisedVisibleHosts() {
+    return this._otherTzPeerPresent() ? VISIBLE_HOSTS_DEFERRED : VISIBLE_HOSTS_SOLE;
+  }
+
+  // Whether another real TimeZero instance is currently on the network. A peer
+  // counts only if it broadcast recently (stale beacons mean it's gone) and
+  // looks like a TZ sync peer rather than an unrelated host.
+  _otherTzPeerPresent() {
+    const now = Date.now();
+    for (const peer of this.peers.values()) {
+      if (now - (peer.lastSeen ?? 0) > PEER_STALE_MS)
+        continue;
+      if (peer.canSync && (peer.deviceType || "").startsWith("TZ"))
+        return true;
+    }
+    return false;
+  }
+
   // The highest anchor tick advertised by any peer we've heard from.
   _highestPeerTick() {
     let highest = 0;
@@ -538,6 +576,7 @@ export class TimeZeroSync {
         if (!peer || peer.uuid?.endsWith(this.uuid))
           return;
         const known = this.peers.get(rinfo.address);
+        peer.lastSeen = Date.now();
         this.peers.set(rinfo.address, peer);
         if (!known)
           this.app.debug(
@@ -576,8 +615,7 @@ export class TimeZeroSync {
         userId: this.userId,
         anchorWatchTick: this.anchorTick,
         currentTick: this.anchorTick,
-        // High so we win TZ's master election and it pulls from us.
-        visibleHosts: 99,
+        visibleHosts: this._advertisedVisibleHosts(),
       }),
       "utf8",
     );

--- a/test/timezero-sync.test.js
+++ b/test/timezero-sync.test.js
@@ -207,6 +207,60 @@ describe("discovery beacon", () => {
   });
 });
 
+// Regression for issue #36: a flat visibleHosts: 99 hijacked the master
+// election two real TZ Professional peers run between themselves to sync
+// routes/marks. We advertise high only when no other TZ peer is visible, and
+// step aside otherwise; our own TZ->plugin pull doesn't depend on the field.
+describe("advertised visibleHosts (master-election deference)", () => {
+  const recent = (extra) => ({
+    canSync: true,
+    deviceType: "TZ Professional",
+    lastSeen: Date.now(),
+    ...extra,
+  });
+
+  test("advertises a high count when we're the only TZ peer", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    assert.equal(sync._advertisedVisibleHosts(), 99);
+  });
+
+  test("steps aside when another real TZ peer is visible", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    sync.peers.set("192.168.1.108", recent({ name: "TZPRO-NAVPC" }));
+    assert.equal(sync._advertisedVisibleHosts(), 1);
+  });
+
+  test("ignores a TZ peer whose beacon has gone stale", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    sync.peers.set(
+      "192.168.1.108",
+      recent({ name: "TZPRO-NAVPC", lastSeen: Date.now() - 60000 }),
+    );
+    assert.equal(sync._advertisedVisibleHosts(), 99);
+  });
+
+  test("ignores a non-TZ host that happens to be on the network", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    sync.peers.set(
+      "192.168.1.50",
+      recent({ deviceType: "SomeOtherDevice" }),
+    );
+    assert.equal(sync._advertisedVisibleHosts(), 99);
+  });
+
+  test("the beacon carries the deferred count when a TZ peer is present", () => {
+    const sync = new TimeZeroSync(stubApp(), {});
+    sync.peers.set("192.168.1.108", recent({ name: "TZPRO-NAVPC" }));
+    const beacon = buildBeacon({
+      hostName: "SignalK",
+      uuid: "x",
+      anchorWatchTick: 7,
+      visibleHosts: sync._advertisedVisibleHosts(),
+    });
+    assert.equal(beacon.split(";")[8], "1");
+  });
+});
+
 describe("My TIMEZERO user id pairing", () => {
   test("advertises the user id in beacon field 4", () => {
     const f = buildBeacon({


### PR DESCRIPTION
Fixes #36.

The sync beacon hardcoded `visibleHosts: 99` so TimeZero would always elect the plugin as sync master and pull the anchor from it. That's necessary for the plugin→TZ direction — the plugin never POSTs to TZ, so a plugin-side anchor raise/drop reaches TZ only when TZ pulls from us, which requires winning the election. But with two real TZ Professional peers on the LAN, they run that same master election between themselves to sync routes/marks, and a permanent `99` from the plugin wins it and stalls their sync (the phantom-master state in the issue).

This advertises the high count only when no other real TZ peer is currently visible, and steps aside to `1` when one is present:

- Sole authority (plugin only): still wins election, TZ still pulls plugin-side raise/drop — unchanged.
- Two TZ peers present: the plugin no longer contends, so the real machines sync with each other normally.

The plugin's own TZ→plugin pull is gated on the anchor tick and `isTrustedPeer`, not on `visibleHosts`, so anchor sync into Signal K is unaffected in both cases.

"Currently visible" means a peer whose beacon arrived within the last few seconds (`PEER_STALE_MS`) and advertises a TZ sync device type, so a TZ machine that shuts down stops suppressing our high count on the next beacon.

## Tested

- `npm test` — full suite passes (343/343), including 5 new cases covering sole-authority, deference to a live TZ peer, ignoring a stale peer, ignoring a non-TZ host, and the deferred value on the wire.
- `npm run format:check` — eslint + prettier clean.
