### PR TITLE
Clean up mock app temp data dirs left behind by tests

### DIFF
--- a/test/mockApp.js
+++ b/test/mockApp.js
@@ -2,6 +2,18 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
+// Every temp dir handed out by getDataDirPath(), so none survive the run.
+// Tests that want the dir gone mid-run still call cleanupDataDir(); this is
+// the backstop for the ones that don't (and on some platforms os.tmpdir() is
+// a RAM-backed tmpfs, so leaked dirs cost memory until reboot).
+const tempDataDirs = new Set();
+let exitHookInstalled = false;
+
+function removeTempDataDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+  tempDataDirs.delete(dir);
+}
+
 // A fake SignalK `app` for driving the plugin in tests. Every method the
 // plugin touches is a recorder; assertions read back from `calls` and the
 // delta helpers. getSelfPath reads a settable map so tests can stage a GPS
@@ -9,11 +21,21 @@ import path from "path";
 export function createMockApp(overrides = {}) {
   // Lazily-created per-app temp data dir, mirroring app.getDataDirPath() in the
   // real server. Only tests that touch it (e.g. the icon routes) pay for it;
-  // they should call cleanupDataDir() when done.
+  // whatever isn't cleaned up explicitly is swept on process exit.
   let dataDir = null;
   const getDataDirPath = () => {
-    if (!dataDir)
+    if (!dataDir) {
       dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "aa-plugin-"));
+      tempDataDirs.add(dataDir);
+      if (!exitHookInstalled) {
+        exitHookInstalled = true;
+        // exit handlers must be synchronous; rmSync is.
+        process.on("exit", () => {
+          for (const dir of [...tempDataDirs])
+            removeTempDataDir(dir);
+        });
+      }
+    }
     return dataDir;
   };
   const calls = {
@@ -74,7 +96,7 @@ export function createMockApp(overrides = {}) {
     dataDir: getDataDirPath,
     cleanupDataDir: () => {
       if (dataDir)
-        fs.rmSync(dataDir, { recursive: true, force: true });
+        removeTempDataDir(dataDir);
       dataDir = null;
     },
     // Forget everything recorded so far — handy between phases of one test.

--- a/test/mockApp.js
+++ b/test/mockApp.js
@@ -29,10 +29,17 @@ export function createMockApp(overrides = {}) {
       tempDataDirs.add(dataDir);
       if (!exitHookInstalled) {
         exitHookInstalled = true;
-        // exit handlers must be synchronous; rmSync is.
+        // exit handlers must be synchronous; rmSync is. One undeletable dir
+        // must not strand the rest, so each removal stands alone — and a
+        // failure here should never fail an otherwise green run.
         process.on("exit", () => {
-          for (const dir of [...tempDataDirs])
-            removeTempDataDir(dir);
+          for (const dir of [...tempDataDirs]) {
+            try {
+              removeTempDataDir(dir);
+            } catch {
+              tempDataDirs.delete(dir);
+            }
+          }
         });
       }
     }


### PR DESCRIPTION
## Problem

`createMockApp()`'s `getDataDirPath()` mints a temp dir with `mkdtemp` on first use, mirroring the real server's `app.getDataDirPath()`. The comment above it says tests "should call `cleanupDataDir()` when done" — `session-log.test.js` and `http-routes.test.js` do, via `afterEach`, but `index.test.js` drives the plugin through a `setup()` helper with no such hook.

So every run leaves directories behind. On a full `npm test`: **14 leaked dirs per run**. They accumulate indefinitely — I found 96 on a Raspberry Pi, where `os.tmpdir()` is a RAM-backed tmpfs, so they cost memory until reboot.

## Fix

Track every dir `getDataDirPath()` hands out and sweep any survivors from a single `process.on("exit")` handler. Explicit `cleanupDataDir()` calls still work and now share the same bookkeeping, so the set doesn't retain already-deleted paths.

This is a module-level backstop rather than an `afterEach` added to `index.test.js`, because the leak comes from a helper called by many tests — per-call-site cleanup is easy to miss and new tests would silently reintroduce it.

The second commit isolates each removal in the sweep: a throwing `rmSync` (EACCES/EBUSY on some hosts) would otherwise abandon every directory after it in the loop, reinstating the very leak this fixes. A failed sweep also never fails an otherwise green run.

## Testing

- Full suite before/after on a cleaned `/tmp`, fix stashed and restored to A/B it: **14 leaked → 0**, 259 tests passing in both cases.
- Fault injection with `rmSync` stubbed to throw on one of three tracked dirs: the other two are still removed and the process exits 0. Without the per-dir isolation the same failure stranded all three.